### PR TITLE
Update and add eng and nld names and labels, pop data

### DIFF
--- a/data/856/870/33/85687033.geojson
+++ b/data/856/870/33/85687033.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "LB"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Limburg"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":51.234821,
     "lbl:longitude":5.938683,
     "lbl:min_zoom":8.0,
@@ -247,9 +253,6 @@
     "name:nld_x_preferred":[
         "Limburg"
     ],
-    "name:nld_x_variant":[
-        "Zuid-Limburg"
-    ],
     "name:nno_x_preferred":[
         "Limburg"
     ],
@@ -450,8 +453,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"2,169",
     "statoids:area_mi":"838",
     "statoids:as_of_date":"2012-01-01",
@@ -503,12 +506,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462695,
+    "wof:lastmodified":1620425239,
     "wof:name":"Limburg",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":1123075,
+    "wof:population":1117201,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"LB",

--- a/data/856/870/35/85687035.geojson
+++ b/data/856/870/35/85687035.geojson
@@ -14,13 +14,19 @@
     "geom:longitude":5.184977,
     "iso:country":"NL",
     "label:eng_x_preferred_longname":[
-        "Noord-Brabant Province"
+        "North Brabant Province"
     ],
     "label:eng_x_preferred_placetype":[
         "province"
     ],
     "label:eng_x_preferred_shortcode":[
         "NB"
+    ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Noord-Brabant"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
     ],
     "lbl:latitude":51.515505,
     "lbl:longitude":5.353093,
@@ -90,9 +96,6 @@
         "Brab\u00e0nt Setentriun\u00e0\u0142"
     ],
     "name:eng_x_preferred":[
-        "Noord-Brabant"
-    ],
-    "name:eng_x_variant":[
         "North Brabant"
     ],
     "name:epo_x_preferred":[
@@ -424,8 +427,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"4,943",
     "statoids:area_mi":"1,908",
     "statoids:as_of_date":"2012-01-01",
@@ -477,12 +480,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462696,
-    "wof:name":"Noord-Brabant",
+    "wof:lastmodified":1620425241,
+    "wof:name":"North Brabant",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":2463686,
+    "wof:population":2562955,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"NB",

--- a/data/856/870/37/85687037.geojson
+++ b/data/856/870/37/85687037.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "ZL"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Zeeland"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":51.491688,
     "lbl:longitude":3.815516,
     "lbl:min_zoom":8.0,
@@ -390,8 +396,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"1,793",
     "statoids:area_mi":"692",
     "statoids:as_of_date":"2012-01-01",
@@ -443,12 +449,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462696,
+    "wof:lastmodified":1620425246,
     "wof:name":"Zeeland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":381407,
+    "wof:population":383488,
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"ZL",

--- a/data/856/870/39/85687039.geojson
+++ b/data/856/870/39/85687039.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "UT"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Utrecht"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":52.072602,
     "lbl:longitude":5.181058,
     "lbl:min_zoom":8.0,
@@ -399,8 +405,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"1,363",
     "statoids:area_mi":"526",
     "statoids:as_of_date":"2012-01-01",
@@ -451,12 +457,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462696,
+    "wof:lastmodified":1620425248,
     "wof:name":"Utrecht",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":1237117,
+    "wof:population":1354834,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"UT",

--- a/data/856/870/41/85687041.geojson
+++ b/data/856/870/41/85687041.geojson
@@ -14,13 +14,19 @@
     "geom:longitude":4.462575,
     "iso:country":"NL",
     "label:eng_x_preferred_longname":[
-        "Zuid-Holland Province"
+        "South Holland Province"
     ],
     "label:eng_x_preferred_placetype":[
         "province"
     ],
     "label:eng_x_preferred_shortcode":[
         "ZH"
+    ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Zuid-Holland"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
     ],
     "lbl:latitude":51.946443,
     "lbl:longitude":4.509113,
@@ -99,9 +105,6 @@
         "Ul\u00e0nda Meriudiun\u00e0la"
     ],
     "name:eng_x_preferred":[
-        "Zuid-Holland"
-    ],
-    "name:eng_x_variant":[
         "South Holland"
     ],
     "name:epo_x_preferred":[
@@ -454,8 +457,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"2,877",
     "statoids:area_mi":"1,111",
     "statoids:as_of_date":"2012-01-01",
@@ -512,12 +515,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462696,
-    "wof:name":"Zuid-Holland",
+    "wof:lastmodified":1620425250,
+    "wof:name":"South Holland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":3552407,
+    "wof:population":3708696,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"ZH",

--- a/data/856/870/43/85687043.geojson
+++ b/data/856/870/43/85687043.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "GE"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Gelderland"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":52.107152,
     "lbl:longitude":5.875753,
     "lbl:min_zoom":8.0,
@@ -423,8 +429,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"5,015",
     "statoids:area_mi":"1,936",
     "statoids:as_of_date":"2012-01-01",
@@ -476,12 +482,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462696,
+    "wof:lastmodified":1620425235,
     "wof:name":"Gelderland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":2010745,
+    "wof:population":2085952,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"GE",

--- a/data/856/870/45/85687045.geojson
+++ b/data/856/870/45/85687045.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "OV"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Overijssel"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":52.429944,
     "lbl:longitude":6.396928,
     "lbl:min_zoom":8.0,
@@ -416,8 +422,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"3,340",
     "statoids:area_mi":"1,289",
     "statoids:as_of_date":"2012-01-01",
@@ -469,12 +475,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462697,
+    "wof:lastmodified":1620425245,
     "wof:name":"Overijssel",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":1137668,
+    "wof:population":1162406,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"OV",

--- a/data/856/870/49/85687049.geojson
+++ b/data/856/870/49/85687049.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "FL"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Flevoland"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":52.565887,
     "lbl:longitude":5.547632,
     "lbl:min_zoom":8.0,
@@ -423,8 +429,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"1,412",
     "statoids:area_mi":"545",
     "statoids:as_of_date":"2012-01-01",
@@ -476,12 +482,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462697,
+    "wof:lastmodified":1620425231,
     "wof:name":"Flevoland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":395525,
+    "wof:population":423021,
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"FL",

--- a/data/856/870/51/85687051.geojson
+++ b/data/856/870/51/85687051.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "DR"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Drenthe"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":52.887876,
     "lbl:longitude":6.657571,
     "lbl:min_zoom":8.0,
@@ -414,8 +420,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"2,655",
     "statoids:area_mi":"1,025",
     "statoids:as_of_date":"2012-01-01",
@@ -466,12 +472,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462697,
+    "wof:lastmodified":1620425229,
     "wof:name":"Drenthe",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":490807,
+    "wof:population":493682,
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"DR",

--- a/data/856/870/53/85687053.geojson
+++ b/data/856/870/53/85687053.geojson
@@ -14,13 +14,19 @@
     "geom:longitude":4.911635,
     "iso:country":"NL",
     "label:eng_x_preferred_longname":[
-        "Noord-Holland Province"
+        "North Holland Province"
     ],
     "label:eng_x_preferred_placetype":[
         "province"
     ],
     "label:eng_x_preferred_shortcode":[
         "NH"
+    ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Noord-Holland"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
     ],
     "lbl:latitude":52.827683,
     "lbl:longitude":4.955985,
@@ -93,9 +99,6 @@
         "Ul\u00e0nda Setentriun\u00e0la"
     ],
     "name:eng_x_preferred":[
-        "Noord-Holland"
-    ],
-    "name:eng_x_variant":[
         "North Holland"
     ],
     "name:epo_x_preferred":[
@@ -421,8 +424,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"2,663",
     "statoids:area_mi":"1,028",
     "statoids:as_of_date":"2012-01-01",
@@ -473,12 +476,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462697,
-    "wof:name":"Noord-Holland",
+    "wof:lastmodified":1620425243,
+    "wof:name":"North Holland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":2709822,
+    "wof:population":2879527,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"NH",

--- a/data/856/870/55/85687055.geojson
+++ b/data/856/870/55/85687055.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "FR"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Friesland"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":53.154635,
     "lbl:longitude":5.692145,
     "lbl:min_zoom":8.0,
@@ -424,8 +430,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"3,359",
     "statoids:area_mi":"1,297",
     "statoids:as_of_date":"2012-01-01",
@@ -475,12 +481,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462697,
+    "wof:lastmodified":1620425232,
     "wof:name":"Friesland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":647214,
+    "wof:population":649957,
     "wof:population_rank":11,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"FR",

--- a/data/856/870/59/85687059.geojson
+++ b/data/856/870/59/85687059.geojson
@@ -22,6 +22,12 @@
     "label:eng_x_preferred_shortcode":[
         "GR"
     ],
+    "label:nld_x_preferred_longname":[
+        "Provincie Groningen"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "provincie"
+    ],
     "lbl:latitude":53.307841,
     "lbl:longitude":6.715733,
     "lbl:min_zoom":8.0,
@@ -402,8 +408,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"statoids",
-    "src:population_date":"2012-01-01",
+    "src:population":"wk",
+    "src:population_date":"2020-01-01",
     "statoids:area_km":"2,346",
     "statoids:area_mi":"906",
     "statoids:as_of_date":"2012-01-01",
@@ -454,12 +460,12 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1607462698,
+    "wof:lastmodified":1620425237,
     "wof:name":"Groningen",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",
-    "wof:population":580875,
+    "wof:population":585866,
     "wof:population_rank":11,
     "wof:repo":"whosonfirst-data-admin-nl",
     "wof:shortcode":"GR",


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1640

For each region in this repo, this PR:

- Updates and adds English and Dutch `label:` properties
- Corrects English and Dutch `name:` properties
- Updates population data (source, pop, pop year) with more accurate data (sourced from Wikipedia)

No PIP work, can merge once approved.