### PR TITLE
Name fixes for four Frisian places and province

### DIFF
--- a/data/101/806/167/101806167.geojson
+++ b/data/101/806/167/101806167.geojson
@@ -33,17 +33,11 @@
     "name:deu_x_preferred":[
         "Grou"
     ],
-    "name:dut_x_variant":[
-        "Grouw"
-    ],
     "name:eng_x_preferred":[
         "Grou"
     ],
     "name:fra_x_preferred":[
         "Grou"
-    ],
-    "name:fra_x_variant":[
-        "Grouw"
     ],
     "name:fry_x_preferred":[
         "Grou"
@@ -55,19 +49,19 @@
         "Grou"
     ],
     "name:ltz_x_preferred":[
-        "Grouw"
+        "Grou"
     ],
     "name:nan_x_preferred":[
-        "Grouw"
+        "Grou"
     ],
     "name:nds_nld_x_preferred":[
-        "Grouw"
+        "Grou"
     ],
     "name:nld_x_preferred":[
-        "Grouw"
+        "Grou"
     ],
     "name:nld_x_variant":[
-        "Grou"
+        "Grouw"
     ],
     "name:por_x_preferred":[
         "Grou"
@@ -85,7 +79,7 @@
         "Grou"
     ],
     "name:zho_min_nan_x_preferred":[
-        "Grouw"
+        "Grou"
     ],
     "qs:a0":"Nederland",
     "qs:a1":"*Friesland",
@@ -141,7 +135,7 @@
     ],
     "wof:id":101806167,
     "wof:lastmodified":1582362734,
-    "wof:name":"Grouw",
+    "wof:name":"Grou",
     "wof:parent_id":404473775,
     "wof:placetype":"locality",
     "wof:population":5737,

--- a/data/101/806/177/101806177.geojson
+++ b/data/101/806/177/101806177.geojson
@@ -27,9 +27,6 @@
     "name:dan_x_preferred":[
         "Jirnsum"
     ],
-    "name:dut_x_variant":[
-        "Irnsum"
-    ],
     "name:eng_x_preferred":[
         "Jirnsum"
     ],
@@ -43,25 +40,25 @@
         "Jirnsum"
     ],
     "name:nan_x_preferred":[
-        "Irnsum"
-    ],
-    "name:nds_nld_x_preferred":[
-        "Irnsum"
-    ],
-    "name:nld_x_preferred":[
-        "Irnsum"
-    ],
-    "name:nld_x_variant":[
         "Jirnsum"
     ],
-    "name:pol_x_preferred":[
+    "name:nds_nld_x_preferred":[
+        "Jirnsum"
+    ],
+    "name:nld_x_preferred":[
+        "Jirnsum"
+    ],
+    "name:nld_x_variant":[
         "Irnsum"
+    ],
+    "name:pol_x_preferred":[
+        "Jirnsum"
     ],
     "name:rus_x_preferred":[
         "\u0418\u0440\u043d\u0441\u044e\u043c"
     ],
     "name:zho_min_nan_x_preferred":[
-        "Irnsum"
+        "Jirnsum"
     ],
     "qs:a0":"Nederland",
     "qs:a1":"*Friesland",
@@ -117,7 +114,7 @@
     ],
     "wof:id":101806177,
     "wof:lastmodified":1582362739,
-    "wof:name":"Irnsum",
+    "wof:name":"Jirnsum",
     "wof:parent_id":404473775,
     "wof:placetype":"locality",
     "wof:population":1278,

--- a/data/101/837/967/101837967.geojson
+++ b/data/101/837/967/101837967.geojson
@@ -52,13 +52,13 @@
         "De Vesterynas"
     ],
     "name:nan_x_preferred":[
-        "Zwaagwesteinde"
+        "De Westereen"
     ],
     "name:nld_x_preferred":[
-        "Zwaagwesteinde"
+        "De Westereen"
     ],
     "name:nld_x_variant":[
-        "De Westereen"
+        "Zwaagwesteinde"
     ],
     "qs:a0":"Nederland",
     "qs:a1":"*Friesland",
@@ -115,7 +115,7 @@
         "dut"
     ],
     "wof:lastmodified":1582362689,
-    "wof:name":"Zwaagwesteinde",
+    "wof:name":"De Westereen",
     "wof:parent_id":404474681,
     "wof:placetype":"locality",
     "wof:population":5175,

--- a/data/101/874/293/101874293.geojson
+++ b/data/101/874/293/101874293.geojson
@@ -47,22 +47,22 @@
         "Eastermar"
     ],
     "name:ltz_x_preferred":[
-        "Oostermeer"
+        "Eastermar"
     ],
     "name:nan_x_preferred":[
         "Eastermar"
     ],
     "name:nld_x_preferred":[
-        "Oostermeer"
+        "Eastermar"
     ],
     "name:nld_x_variant":[
-        "Eastermar"
+        "Oostermeer"
     ],
     "name:spa_x_preferred":[
         "Eastermar"
     ],
     "name:swe_x_preferred":[
-        "Oostermeer"
+        "Eastermar"
     ],
     "name:zho_x_preferred":[
         "\u5967\u65af\u7279\u6885\u723e"
@@ -124,7 +124,7 @@
         "dut"
     ],
     "wof:lastmodified":1582362625,
-    "wof:name":"Oostermeer",
+    "wof:name":"Eastermar",
     "wof:parent_id":404474343,
     "wof:placetype":"locality",
     "wof:population":1572,

--- a/data/856/870/55/85687055.geojson
+++ b/data/856/870/55/85687055.geojson
@@ -14,7 +14,7 @@
     "geom:longitude":5.692202,
     "iso:country":"NL",
     "label:eng_x_preferred_longname":[
-        "Friesland Province"
+        "Frisia Province"
     ],
     "label:eng_x_preferred_placetype":[
         "province"
@@ -23,7 +23,7 @@
         "FR"
     ],
     "label:nld_x_preferred_longname":[
-        "Provincie Friesland"
+        "Provincie Frysl\u00e2n"
     ],
     "label:nld_x_preferred_placetype":[
         "provincie"
@@ -95,7 +95,7 @@
         "Fr\u00ec\u015bia"
     ],
     "name:eng_x_preferred":[
-        "Friesland"
+        "Frisia"
     ],
     "name:epo_x_preferred":[
         "Frislando"
@@ -239,6 +239,9 @@
         "\u092b\u094d\u0930\u093e\u0907\u091c\u0932\u094d\u092f\u093e\u0928\u094d\u0921"
     ],
     "name:nld_x_preferred":[
+        "Frysl\u00e2n"
+    ],
+    "name:nld_x_colloquial":[
         "Friesland"
     ],
     "name:nld_x_variant":[
@@ -482,7 +485,7 @@
         "fry"
     ],
     "wof:lastmodified":1620425232,
-    "wof:name":"Friesland",
+    "wof:name":"Frisia",
     "wof:parent_id":85633337,
     "wof:placetype":"region",
     "wof:placetype_local":"province",


### PR DESCRIPTION
This uses the current names of four Frisian villages as used in Dutch
(and Frisian), which have in the past half century supplanted their
older Dutch forms. The villages are Jirnsum, Grou, Eastermar, and De
Westereen.

For the province of Frisia its English exonym is used, and in Dutch the
official name. The Dutch vernacular name is kept in `nld_x_colloquial`.

Some remaining `dut_*` keys were removed in favour of their `nld_*`
companions.

-----

Possible fix for https://github.com/whosonfirst-data/whosonfirst-data/issues/2008

I can supply plenty of examples of current day use of these place names in Dutch. Tourist and municipal websites in particular are most likely to be the most representative. Let me know if you need more sources than just my input.

For Dutch places, and Frisian places in particular, I can recommend looking to OpenStreetMap for up-to-date names if you want to automate this for more places. The ones I've picked are the more obvious ones.