### PR TITLE
NL concordances, placetype local, and more

### DIFF
--- a/data/114/196/073/5/1141960735.geojson
+++ b/data/114/196/073/5/1141960735.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.014137,
     "geom:longitude":5.537312,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.018652,
     "lbl:longitude":5.533441,
     "lbl:max_zoom":14.0,
@@ -58,9 +67,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1900",
         "eg:gisco_id":"NL_GM1900",
         "eurostat:nuts_2021_id":"GM1900"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz"
@@ -76,7 +87,7 @@
         }
     ],
     "wof:id":1141960735,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878829,
     "wof:name":"Sudwest-Fryslan",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/114/196/073/7/1141960737.geojson
+++ b/data/114/196/073/7/1141960737.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":52.91651,
     "geom:longitude":5.723508,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.922829,
     "lbl:longitude":5.783157,
     "lbl:max_zoom":14.0,
@@ -124,9 +133,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1940",
         "eg:gisco_id":"NL_GM1940",
         "eurostat:nuts_2021_id":"GM1940"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz"
@@ -142,7 +153,7 @@
         }
     ],
     "wof:id":1141960737,
-    "wof:lastmodified":1684354059,
+    "wof:lastmodified":1695878830,
     "wof:name":"De Fryske Marren",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/115/878/337/7/1158783377.geojson
+++ b/data/115/878/337/7/1158783377.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.819984,
     "geom:longitude":5.949818,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.780074,
     "lbl:longitude":5.940718,
     "lbl:max_zoom":14.0,
@@ -63,9 +72,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1945",
         "eg:gisco_id":"NL_GM1945",
         "eurostat:nuts_2021_id":"GM1945"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"f8c0dc1a07cb73a289cf9e67b7fcd816",
     "wof:hierarchy":[
@@ -78,7 +89,7 @@
         }
     ],
     "wof:id":1158783377,
-    "wof:lastmodified":1684354060,
+    "wof:lastmodified":1695878831,
     "wof:name":"Berg en Dal",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/115/878/749/9/1158787499.geojson
+++ b/data/115/878/749/9/1158787499.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.17697,
     "geom:longitude":5.012587,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.175906,
     "lbl:longitude":4.996732,
     "lbl:max_zoom":14.0,
@@ -126,9 +135,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1904",
         "eg:gisco_id":"NL_GM1904",
         "eurostat:nuts_2021_id":"GM1904"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"a62379ba67c5b3b4cf1b569c70bf199f",
     "wof:hierarchy":[
@@ -141,7 +152,7 @@
         }
     ],
     "wof:id":1158787499,
-    "wof:lastmodified":1684354060,
+    "wof:lastmodified":1695878831,
     "wof:name":"Stichtse Vecht",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/115/879/236/1/1158792361.geojson
+++ b/data/115/879/236/1/1158792361.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.195104,
     "geom:longitude":7.05573,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.187472,
     "lbl:longitude":7.01542,
     "lbl:max_zoom":14.0,
@@ -67,9 +76,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1895",
         "eg:gisco_id":"NL_GM1895",
         "eurostat:nuts_2021_id":"GM1895"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "cbsnl"
@@ -85,7 +96,7 @@
         }
     ],
     "wof:id":1158792361,
-    "wof:lastmodified":1684354060,
+    "wof:lastmodified":1695878831,
     "wof:name":"Oldambt",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/115/880/587/1/1158805871.geojson
+++ b/data/115/880/587/1/1158805871.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.80108,
     "geom:longitude":5.774039,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.81573,
     "lbl:longitude":5.780229,
     "lbl:max_zoom":14.0,
@@ -108,9 +117,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1903",
         "eg:gisco_id":"NL_GM1903",
         "eurostat:nuts_2021_id":"GM1903"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"f3b08eaf57642a025e2683a17c6d6f66",
     "wof:hierarchy":[
@@ -123,7 +134,7 @@
         }
     ],
     "wof:id":1158805871,
-    "wof:lastmodified":1684354060,
+    "wof:lastmodified":1695878832,
     "wof:name":"Eijsden-Margraten",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/115/880/587/3/1158805873.geojson
+++ b/data/115/880/587/3/1158805873.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.336297,
     "geom:longitude":5.994846,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.329039,
     "lbl:longitude":6.006921,
     "lbl:max_zoom":14.0,
@@ -120,9 +129,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1894",
         "eg:gisco_id":"NL_GM1894",
         "eurostat:nuts_2021_id":"GM1894"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"ceb2a00a802a9d5a434fe0b7f029f01c",
     "wof:hierarchy":[
@@ -135,7 +146,7 @@
         }
     ],
     "wof:id":1158805873,
-    "wof:lastmodified":1684354061,
+    "wof:lastmodified":1695878832,
     "wof:name":"Peel en Maas",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/115/881/828/1/1158818281.geojson
+++ b/data/115/881/828/1/1158818281.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.301412,
     "geom:longitude":5.134572,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.30338,
     "lbl:longitude":5.125751,
     "lbl:max_zoom":14.0,
@@ -106,9 +115,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1942",
         "eg:gisco_id":"NL_GM1942",
         "eurostat:nuts_2021_id":"GM1942"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz"
@@ -124,7 +135,7 @@
         }
     ],
     "wof:id":1158818281,
-    "wof:lastmodified":1684354061,
+    "wof:lastmodified":1695878832,
     "wof:name":"Gooise Meren",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/115/881/828/7/1158818287.geojson
+++ b/data/115/881/828/7/1158818287.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.829705,
     "geom:longitude":4.949208,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.843759,
     "lbl:longitude":5.002804,
     "lbl:max_zoom":14.0,
@@ -124,9 +133,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1911",
         "eg:gisco_id":"NL_GM1911",
         "eurostat:nuts_2021_id":"GM1911"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz"
@@ -142,7 +153,7 @@
         }
     ],
     "wof:id":1158818287,
-    "wof:lastmodified":1684354062,
+    "wof:lastmodified":1695878833,
     "wof:name":"Hollands Kroon",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/115/882/473/7/1158824737.geojson
+++ b/data/115/882/473/7/1158824737.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.998892,
     "geom:longitude":4.607058,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.991975,
     "lbl:longitude":4.619999,
     "lbl:max_zoom":14.0,
@@ -116,9 +125,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1892",
         "eg:gisco_id":"NL_GM1892",
         "eurostat:nuts_2021_id":"GM1892"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"f094997ac1ba076d3a602c8b0eb4da81",
     "wof:hierarchy":[
@@ -131,7 +142,7 @@
         }
     ],
     "wof:id":1158824737,
-    "wof:lastmodified":1684354062,
+    "wof:lastmodified":1695878834,
     "wof:name":"Zuidplas",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/115/882/473/9/1158824739.geojson
+++ b/data/115/882/473/9/1158824739.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.065419,
     "geom:longitude":4.766097,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.06324,
     "lbl:longitude":4.767706,
     "lbl:max_zoom":14.0,
@@ -113,9 +122,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1901",
         "eg:gisco_id":"NL_GM1901",
         "eurostat:nuts_2021_id":"GM1901"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"bd09dbd3234ca3975ec4e18c18180568",
     "wof:hierarchy":[
@@ -128,7 +139,7 @@
         }
     ],
     "wof:id":1158824739,
-    "wof:lastmodified":1684354062,
+    "wof:lastmodified":1695878834,
     "wof:name":"Bodegraven-Reeuwijk",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/115/882/474/1/1158824741.geojson
+++ b/data/115/882/474/1/1158824741.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.747698,
     "geom:longitude":4.123821,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.746792,
     "lbl:longitude":4.125539,
     "lbl:max_zoom":14.0,
@@ -123,9 +132,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1924",
         "eg:gisco_id":"NL_GM1924",
         "eurostat:nuts_2021_id":"GM1924"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz"
@@ -141,7 +152,7 @@
         }
     ],
     "wof:id":1158824741,
-    "wof:lastmodified":1684354063,
+    "wof:lastmodified":1695878834,
     "wof:name":"Goeree-Overflakkee",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/115/882/474/3/1158824743.geojson
+++ b/data/115/882/474/3/1158824743.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.890808,
     "geom:longitude":4.801552,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.883455,
     "lbl:longitude":4.799103,
     "lbl:max_zoom":14.0,
@@ -110,9 +119,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1927",
         "eg:gisco_id":"NL_GM1978",
         "eurostat:nuts_2021_id":"GM1978"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"a0feb3ab7ac34f883702c45dd7ca6764",
     "wof:hierarchy":[
@@ -125,7 +136,7 @@
         }
     ],
     "wof:id":1158824743,
-    "wof:lastmodified":1684354067,
+    "wof:lastmodified":1695878838,
     "wof:name":"Molenwaard",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/115/882/474/7/1158824747.geojson
+++ b/data/115/882/474/7/1158824747.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.832147,
     "geom:longitude":4.274949,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.834661,
     "lbl:longitude":4.275047,
     "lbl:max_zoom":14.0,
@@ -105,9 +114,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1930",
         "eg:gisco_id":"NL_GM1930",
         "eurostat:nuts_2021_id":"GM1930"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz"
@@ -123,7 +134,7 @@
         }
     ],
     "wof:id":1158824747,
-    "wof:lastmodified":1684354067,
+    "wof:lastmodified":1695878839,
     "wof:name":"Nissewaard",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/115/882/474/9/1158824749.geojson
+++ b/data/115/882/474/9/1158824749.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.952394,
     "geom:longitude":4.737227,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.954208,
     "lbl:longitude":4.73493,
     "lbl:max_zoom":14.0,
@@ -107,9 +116,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1931",
         "eg:gisco_id":"NL_GM1931",
         "eurostat:nuts_2021_id":"GM1931"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geomhash":"1e3ffa1aded0323710e32575a7488dba",
     "wof:hierarchy":[
@@ -122,7 +133,7 @@
         }
     ],
     "wof:id":1158824749,
-    "wof:lastmodified":1684354067,
+    "wof:lastmodified":1695878839,
     "wof:name":"Krimpenerwaard",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/136/251/281/136251281.geojson
+++ b/data/136/251/281/136251281.geojson
@@ -301,11 +301,13 @@
         "gaul:id":"176",
         "gn:id":7626844,
         "ioc:id":"AHO",
+        "iso:code":"NL",
         "itu:id":"ATN",
         "marc:id":"ca",
         "uncrt:id":"NA",
         "wmo:id":"NU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -321,7 +323,7 @@
         }
     ],
     "wof:id":136251281,
-    "wof:lastmodified":1694639813,
+    "wof:lastmodified":1695881384,
     "wof:name":"Caribbean Netherlands",
     "wof:parent_id":136253051,
     "wof:placetype":"dependency",

--- a/data/404/473/703/404473703.geojson
+++ b/data/404/473/703/404473703.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":53.294851,
     "geom:longitude":6.597163,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.294851,
     "lbl:longitude":6.596063,
     "lbl:max_zoom":15.0,
@@ -175,13 +184,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0005",
         "hasc:id":"NL.GR.BD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab5204d20bbc9f23c917e568fd53eb6a",
+    "wof:geomhash":"3d197b9c4654b82b0500a47de8324254",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404473703,
-    "wof:lastmodified":1582362776,
+    "wof:lastmodified":1695878760,
     "wof:name":"Bedum",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/705/404473705.geojson
+++ b/data/404/473/705/404473705.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014766,
-    "geom:area_square_m":109632343.194481,
+    "geom:area_square_m":109632343.194479,
     "geom:bbox":"7.01544587002,53.0389694917,7.20424323889,53.1607736702",
     "geom:latitude":53.098607,
     "geom:longitude":7.121181,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.097267,
     "lbl:longitude":7.138292,
     "lbl:max_zoom":15.0,
@@ -160,13 +169,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0007",
         "hasc:id":"NL.GR.BL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f861618f246dc107ec063c4c28a9a19",
+    "wof:geomhash":"84493d6015e6b3c15381dd234627620b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473705,
-    "wof:lastmodified":1582362775,
+    "wof:lastmodified":1695878760,
     "wof:name":"Bellingwedde",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/709/404473709.geojson
+++ b/data/404/473/709/404473709.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006159,
-    "geom:area_square_m":45538957.237982,
+    "geom:area_square_m":45538957.23798,
     "geom:bbox":"6.62584721946,53.2350556221,6.77252679288,53.3129637289",
     "geom:latitude":53.278843,
     "geom:longitude":6.691451,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.275566,
     "lbl:longitude":6.66843,
     "lbl:max_zoom":15.0,
@@ -154,13 +163,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0009",
         "hasc:id":"NL.GR.TB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac4d327a82b8c24d5266dc0a3daec8ee",
+    "wof:geomhash":"817e52802a1d42a0d343bcbf33eccefb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404473709,
-    "wof:lastmodified":1582362766,
+    "wof:lastmodified":1695878758,
     "wof:name":"Ten Boer",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/711/404473711.geojson
+++ b/data/404/473/711/404473711.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.320025,
     "geom:longitude":6.929926,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.289139,
     "lbl:longitude":6.954037,
     "lbl:max_zoom":14.0,
@@ -196,10 +205,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0010",
         "eg:gisco_id":"NL_GM0010",
         "eurostat:nuts_2021_id":"GM0010",
         "hasc:id":"NL.GR.DE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -216,7 +227,7 @@
         }
     ],
     "wof:id":404473711,
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695878770,
     "wof:name":"Delfzijl",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/713/404473713.geojson
+++ b/data/404/473/713/404473713.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.222234,
     "geom:longitude":6.563382,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.223054,
     "lbl:longitude":6.561683,
     "lbl:max_zoom":13.0,
@@ -332,10 +341,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0014",
         "eg:gisco_id":"NL_GM0014",
         "eurostat:nuts_2021_id":"GM0014",
         "hasc:id":"NL.GR.GR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -351,7 +362,7 @@
         }
     ],
     "wof:id":404473713,
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695878770,
     "wof:name":"Groningen",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/715/404473715.geojson
+++ b/data/404/473/715/404473715.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011799,
-    "geom:area_square_m":87377523.957331,
+    "geom:area_square_m":87377523.957332,
     "geom:bbox":"6.17523487069,53.1350763768,6.40621212695,53.2559538942",
     "geom:latitude":53.208643,
     "geom:longitude":6.273222,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.216303,
     "lbl:longitude":6.2619,
     "lbl:max_zoom":15.0,
@@ -166,13 +175,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0015",
         "hasc:id":"NL.GR.GT"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a850990e1ef6225efb845a69a0b36ab",
+    "wof:geomhash":"fc78a5add0cdf24d015325df961761ef",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473715,
-    "wof:lastmodified":1582362773,
+    "wof:lastmodified":1695878759,
     "wof:name":"Grootegast",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/717/404473717.geojson
+++ b/data/404/473/717/404473717.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006814,
-    "geom:area_square_m":50523881.552385,
+    "geom:area_square_m":50523881.552384,
     "geom:bbox":"6.54837759441,53.1061987288,6.69536692885,53.19659159",
     "geom:latitude":53.154548,
     "geom:longitude":6.631058,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.154681,
     "lbl:longitude":6.636848,
     "lbl:max_zoom":15.0,
@@ -97,13 +106,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0017",
         "hasc:id":"NL.GR.HA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"114a984d5c62363ed9b5385c2e45d8a8",
+    "wof:geomhash":"0b97cea8f98362c4bc8dbfb44fd8feb1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -114,7 +125,7 @@
         }
     ],
     "wof:id":404473717,
-    "wof:lastmodified":1582362787,
+    "wof:lastmodified":1695878761,
     "wof:name":"Haren",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/719/404473719.geojson
+++ b/data/404/473/719/404473719.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009802,
-    "geom:area_square_m":72690976.626375,
+    "geom:area_square_m":72690976.62637,
     "geom:bbox":"6.63946807033,53.0709715834,6.82699902681,53.2020203418",
     "geom:latitude":53.147345,
     "geom:longitude":6.746794,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.143944,
     "lbl:longitude":6.738873,
     "lbl:max_zoom":14.0,
@@ -163,13 +172,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0018",
         "hasc:id":"NL.GR.HS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f1d6ef9d93b83981480977c1904f0abb",
+    "wof:geomhash":"36ff253bf0d3165c7136f9266fd1563e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404473719,
-    "wof:lastmodified":1582362786,
+    "wof:lastmodified":1695878761,
     "wof:name":"Hoogezand-Sappemeer",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/721/404473721.geojson
+++ b/data/404/473/721/404473721.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008636,
-    "geom:area_square_m":64022848.955509,
+    "geom:area_square_m":64022848.955519,
     "geom:bbox":"6.28822892374,53.0871349199,6.46707694525,53.2247323438",
     "geom:latitude":53.163345,
     "geom:longitude":6.369254,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.18392,
     "lbl:longitude":6.375445,
     "lbl:max_zoom":15.0,
@@ -280,13 +289,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0022",
         "hasc:id":"NL.GR.LE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8476ba8e9725b0fb8511c81fabfe5db5",
+    "wof:geomhash":"0172d00da94a68aa60143090d4dada55",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -297,7 +308,7 @@
         }
     ],
     "wof:id":404473721,
-    "wof:lastmodified":1582362786,
+    "wof:lastmodified":1695878761,
     "wof:name":"Leek",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/723/404473723.geojson
+++ b/data/404/473/723/404473723.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.340695,
     "geom:longitude":6.728138,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.353082,
     "lbl:longitude":6.760394,
     "lbl:max_zoom":15.0,
@@ -77,10 +86,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0024",
         "eg:gisco_id":"NL_GM0024",
         "eurostat:nuts_2021_id":"GM0024",
         "hasc:id":"NL.GR.LO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -96,7 +107,7 @@
         }
     ],
     "wof:id":404473723,
-    "wof:lastmodified":1684354006,
+    "wof:lastmodified":1695878770,
     "wof:name":"Loppersum",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/727/404473727.geojson
+++ b/data/404/473/727/404473727.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008715,
-    "geom:area_square_m":64627747.526064,
+    "geom:area_square_m":64627747.526065,
     "geom:bbox":"6.17567757664,53.0984433385,6.34695791481,53.2042089878",
     "geom:latitude":53.149428,
     "geom:longitude":6.276465,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.14538,
     "lbl:longitude":6.269606,
     "lbl:max_zoom":15.0,
@@ -157,13 +166,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0025",
         "hasc:id":"NL.GR.MA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29c1483177da43e6e624c7dcfa191c62",
+    "wof:geomhash":"7ce377201357b744012453f6c882f9e7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473727,
-    "wof:lastmodified":1582362791,
+    "wof:lastmodified":1695878762,
     "wof:name":"Marum",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/731/404473731.geojson
+++ b/data/404/473/731/404473731.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.002171,
     "geom:longitude":7.010322,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.002812,
     "lbl:longitude":7.018319,
     "lbl:max_zoom":14.0,
@@ -182,10 +191,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0037",
         "eg:gisco_id":"NL_GM0037",
         "eurostat:nuts_2021_id":"GM0037",
         "hasc:id":"NL.GR.ST"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404473731,
-    "wof:lastmodified":1684354006,
+    "wof:lastmodified":1695878770,
     "wof:name":"Stadskanaal",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/735/404473735.geojson
+++ b/data/404/473/735/404473735.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021377,
-    "geom:area_square_m":158205138.008239,
+    "geom:area_square_m":158205138.008242,
     "geom:bbox":"6.64071073158,53.1682487824,6.91271631903,53.2983523173",
     "geom:latitude":53.235802,
     "geom:longitude":6.784509,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.233555,
     "lbl:longitude":6.782087,
     "lbl:max_zoom":15.0,
@@ -151,13 +160,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0040",
         "hasc:id":"NL.GR.SL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"018df0c031b221d22e41f01d9435180c",
+    "wof:geomhash":"5475f79542a615da43e258a29a670f7f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404473735,
-    "wof:lastmodified":1582362776,
+    "wof:lastmodified":1695878760,
     "wof:name":"Slochteren",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/737/404473737.geojson
+++ b/data/404/473/737/404473737.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.08899,
     "geom:longitude":6.880092,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.085391,
     "lbl:longitude":6.880077,
     "lbl:max_zoom":14.0,
@@ -182,10 +191,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0047",
         "eg:gisco_id":"NL_GM0047",
         "eurostat:nuts_2021_id":"GM0047",
         "hasc:id":"NL.GR.VE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404473737,
-    "wof:lastmodified":1684354006,
+    "wof:lastmodified":1695878770,
     "wof:name":"Veendam",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/739/404473739.geojson
+++ b/data/404/473/739/404473739.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022805,
-    "geom:area_square_m":169860713.853899,
+    "geom:area_square_m":169860713.853902,
     "geom:bbox":"7.01479927569,52.8381961358,7.21744535682,53.0614422303",
     "geom:latitude":52.959454,
     "geom:longitude":7.119607,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.96484,
     "lbl:longitude":7.12627,
     "lbl:max_zoom":15.0,
@@ -160,13 +169,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0048",
         "hasc:id":"NL.GR.VL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ad581721fd63113cb39f74ea088df8b",
+    "wof:geomhash":"ffc96482893b3357a8d2a4dfb9642380",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473739,
-    "wof:lastmodified":1582362764,
+    "wof:lastmodified":1695878758,
     "wof:name":"Vlagtwedde",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/749/404473749.geojson
+++ b/data/404/473/749/404473749.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013827,
-    "geom:area_square_m":102104115.122959,
+    "geom:area_square_m":102104115.122963,
     "geom:bbox":"6.42057425553,53.256436184,6.57620272969,53.4263454963",
     "geom:latitude":53.32967,
     "geom:longitude":6.507669,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.320525,
     "lbl:longitude":6.519428,
     "lbl:max_zoom":15.0,
@@ -160,13 +169,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0053",
         "hasc:id":"NL.GR.WM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d81743e8b49fed8082cc3bc11dc732c8",
+    "wof:geomhash":"34c86feaa80ff6de16502298522d57ea",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473749,
-    "wof:lastmodified":1582362773,
+    "wof:lastmodified":1695878759,
     "wof:name":"Winsum",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/753/404473753.geojson
+++ b/data/404/473/753/404473753.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017286,
-    "geom:area_square_m":127816455.027924,
+    "geom:area_square_m":127816455.027915,
     "geom:bbox":"6.23174908537,53.2076143179,6.51144242294,53.3410262658",
     "geom:latitude":53.273223,
     "geom:longitude":6.374584,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.278072,
     "lbl:longitude":6.385998,
     "lbl:max_zoom":15.0,
@@ -172,13 +181,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0056",
         "hasc:id":"NL.GR.ZU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a5257e87ece9c4a08a5d5173f4cd58da",
+    "wof:geomhash":"ee9d2e7fca2d845a875204f9683aca9d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404473753,
-    "wof:lastmodified":1582362766,
+    "wof:lastmodified":1695878759,
     "wof:name":"Zuidhorn",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/473/755/404473755.geojson
+++ b/data/404/473/755/404473755.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022891,
-    "geom:area_square_m":168922347.763564,
+    "geom:area_square_m":168922347.763556,
     "geom:bbox":"5.84806110006,53.3006351546,6.19147087704,53.4754310032",
     "geom:latitude":53.360369,
     "geom:longitude":6.034331,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.36436,
     "lbl:longitude":6.033888,
     "lbl:max_zoom":14.0,
@@ -163,14 +172,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0058",
         "hasc:id":"NL.FR.DO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
         "mz"
     ],
-    "wof:geomhash":"c769509fdfdae81da14df3952eb97718",
+    "wof:geomhash":"9e88331222773c7d203bfe5877b5691b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +192,7 @@
         }
     ],
     "wof:id":404473755,
-    "wof:lastmodified":1582362763,
+    "wof:lastmodified":1695878757,
     "wof:name":"Dongeradeel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/757/404473757.geojson
+++ b/data/404/473/757/404473757.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.21668,
     "geom:longitude":6.143136,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.216895,
     "lbl:longitude":6.134173,
     "lbl:max_zoom":14.0,
@@ -178,10 +187,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0059",
         "eg:gisco_id":"NL_GM0059",
         "eurostat:nuts_2021_id":"GM0059",
         "hasc:id":"NL.FR.AC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -197,7 +208,7 @@
         }
     ],
     "wof:id":404473757,
-    "wof:lastmodified":1684354006,
+    "wof:lastmodified":1695878771,
     "wof:name":"Achtkarspelen",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/759/404473759.geojson
+++ b/data/404/473/759/404473759.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.450344,
     "geom:longitude":5.754852,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.443433,
     "lbl:longitude":5.678032,
     "lbl:max_zoom":15.0,
@@ -206,10 +215,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0060",
         "eg:gisco_id":"NL_GM0060",
         "eurostat:nuts_2021_id":"GM0060",
         "hasc:id":"NL.FR.AM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -226,7 +237,7 @@
         }
     ],
     "wof:id":404473759,
-    "wof:lastmodified":1684354006,
+    "wof:lastmodified":1695878771,
     "wof:name":"Ameland",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/763/404473763.geojson
+++ b/data/404/473/763/404473763.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012524,
-    "geom:area_square_m":92589826.859297,
+    "geom:area_square_m":92589826.859296,
     "geom:bbox":"5.5380388503,53.2254671096,5.74930109927,53.3348639397",
     "geom:latitude":53.279645,
     "geom:longitude":5.650398,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.285088,
     "lbl:longitude":5.6607,
     "lbl:max_zoom":15.0,
@@ -146,13 +155,16 @@
         85687055
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "cbsnl:code":"GM0063"
+    },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
         "mz"
     ],
-    "wof:geomhash":"e604972d48fb58962aa40d89574747bf",
+    "wof:geomhash":"1e00a724ab6e9be9d3dc951ed837acb3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -163,7 +175,7 @@
         }
     ],
     "wof:id":404473763,
-    "wof:lastmodified":1582362762,
+    "wof:lastmodified":1695878757,
     "wof:name":"het Bildt",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/767/404473767.geojson
+++ b/data/404/473/767/404473767.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014019,
-    "geom:area_square_m":103850316.009605,
+    "geom:area_square_m":103850316.009614,
     "geom:bbox":"5.43693154385,53.1295236515,5.62083383978,53.265916162",
     "geom:latitude":53.19628,
     "geom:longitude":5.536258,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.201052,
     "lbl:longitude":5.542453,
     "lbl:max_zoom":14.0,
@@ -169,14 +178,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0070",
         "hasc:id":"NL.FR.FR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"4e313d649035a975ed4b74eb8ffbbe02",
+    "wof:geomhash":"8789d35280956b499f9dbcc37e50faf6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +198,7 @@
         }
     ],
     "wof:id":404473767,
-    "wof:lastmodified":1582362775,
+    "wof:lastmodified":1695878760,
     "wof:name":"Franekeradeel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/769/404473769.geojson
+++ b/data/404/473/769/404473769.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.175388,
     "geom:longitude":5.451748,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.175289,
     "lbl:longitude":5.45544,
     "lbl:max_zoom":15.0,
@@ -131,10 +140,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0072",
         "eg:gisco_id":"NL_GM0072",
         "eurostat:nuts_2021_id":"GM0072",
         "hasc:id":"NL.FR.HA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -151,7 +162,7 @@
         }
     ],
     "wof:id":404473769,
-    "wof:lastmodified":1684354006,
+    "wof:lastmodified":1695878771,
     "wof:name":"Harlingen",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/771/404473771.geojson
+++ b/data/404/473/771/404473771.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":52.995987,
     "geom:longitude":5.977911,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.942719,
     "lbl:longitude":6.045416,
     "lbl:max_zoom":14.0,
@@ -223,10 +232,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0074",
         "eg:gisco_id":"NL_GM0074",
         "eurostat:nuts_2021_id":"GM0074",
         "hasc:id":"NL.FR.HE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -242,7 +253,7 @@
         }
     ],
     "wof:id":404473771,
-    "wof:lastmodified":1684354007,
+    "wof:lastmodified":1695878771,
     "wof:name":"Heerenveen",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/773/404473773.geojson
+++ b/data/404/473/773/404473773.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01501,
-    "geom:area_square_m":110924974.964627,
+    "geom:area_square_m":110924974.964633,
     "geom:bbox":"6.04396563564,53.2435024767,6.29436112855,53.3573289922",
     "geom:latitude":53.297513,
     "geom:longitude":6.172225,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.290386,
     "lbl:longitude":6.171966,
     "lbl:max_zoom":15.0,
@@ -160,14 +169,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0079",
         "hasc:id":"NL.FR.KN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
         "mz"
     ],
-    "wof:geomhash":"ef750b8e0ede299561655d922ce17f43",
+    "wof:geomhash":"95ff8bb8e096729b56691467784ebef8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -178,7 +189,7 @@
         }
     ],
     "wof:id":404473773,
-    "wof:lastmodified":1582362787,
+    "wof:lastmodified":1695878761,
     "wof:name":"Kollumerland en Nieuwkruisland",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/775/404473775.geojson
+++ b/data/404/473/775/404473775.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.153771,
     "geom:longitude":5.826308,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.189818,
     "lbl:longitude":5.797428,
     "lbl:max_zoom":14.0,
@@ -322,10 +331,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0080",
         "eg:gisco_id":"NL_GM0080",
         "eurostat:nuts_2021_id":"GM0080",
         "hasc:id":"NL.FR.LW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -341,7 +352,7 @@
         }
     ],
     "wof:id":404473775,
-    "wof:lastmodified":1684354007,
+    "wof:lastmodified":1695878771,
     "wof:name":"Leeuwarden",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/777/404473777.geojson
+++ b/data/404/473/777/404473777.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005583,
-    "geom:area_square_m":41292324.490978,
+    "geom:area_square_m":41292324.49098,
     "geom:bbox":"5.72012102054,53.2240015215,5.83864916664,53.2947209966",
     "geom:latitude":53.260787,
     "geom:longitude":5.779277,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.255179,
     "lbl:longitude":5.792304,
     "lbl:max_zoom":15.0,
@@ -156,13 +165,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0081",
         "hasc:id":"NL.FR.LD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd631e28adc54ba293db6c0d72f52f70",
+    "wof:geomhash":"9c388f6629757262c50a82b06e99907f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -173,7 +184,7 @@
         }
     ],
     "wof:id":404473777,
-    "wof:lastmodified":1582362774,
+    "wof:lastmodified":1695878759,
     "wof:name":"Leeuwarderadeel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/783/404473783.geojson
+++ b/data/404/473/783/404473783.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009419,
-    "geom:area_square_m":69748922.511194,
+    "geom:area_square_m":69748922.511195,
     "geom:bbox":"5.60055670937,53.1660790019,5.74710720238,53.2557620507",
     "geom:latitude":53.209413,
     "geom:longitude":5.674057,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.209145,
     "lbl:longitude":5.660706,
     "lbl:max_zoom":15.0,
@@ -151,12 +160,15 @@
         85687055
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "cbsnl:code":"GM1908"
+    },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d6d7a10f0d4067f7382d498d839cb589",
+    "wof:geomhash":"8d33683e616b4cfb1ba4480f7ac45b92",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -167,7 +179,7 @@
         }
     ],
     "wof:id":404473783,
-    "wof:lastmodified":1582362774,
+    "wof:lastmodified":1695878760,
     "wof:name":"Menameradiel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/785/404473785.geojson
+++ b/data/404/473/785/404473785.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":52.982381,
     "geom:longitude":6.282998,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.988699,
     "lbl:longitude":6.29481,
     "lbl:max_zoom":14.0,
@@ -178,10 +187,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0085",
         "eg:gisco_id":"NL_GM0085",
         "eurostat:nuts_2021_id":"GM0085",
         "hasc:id":"NL.FR.OO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -197,7 +208,7 @@
         }
     ],
     "wof:id":404473785,
-    "wof:lastmodified":1684354007,
+    "wof:lastmodified":1695878772,
     "wof:name":"Ooststellingwerf",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/787/404473787.geojson
+++ b/data/404/473/787/404473787.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.049142,
     "geom:longitude":6.112848,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.019483,
     "lbl:longitude":6.042583,
     "lbl:max_zoom":14.0,
@@ -175,10 +184,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0086",
         "eg:gisco_id":"NL_GM0086",
         "eurostat:nuts_2021_id":"GM0086",
         "hasc:id":"NL.FR.OP"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -194,7 +205,7 @@
         }
     ],
     "wof:id":404473787,
-    "wof:lastmodified":1684354007,
+    "wof:lastmodified":1695878772,
     "wof:name":"Opsterland",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/789/404473789.geojson
+++ b/data/404/473/789/404473789.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.491495,
     "geom:longitude":6.226593,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.490635,
     "lbl:longitude":6.221215,
     "lbl:max_zoom":17.0,
@@ -200,10 +209,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0088",
         "eg:gisco_id":"NL_GM0088",
         "eurostat:nuts_2021_id":"GM0088",
         "hasc:id":"NL.FR.SC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101807407
     ],
@@ -223,7 +234,7 @@
         }
     ],
     "wof:id":404473789,
-    "wof:lastmodified":1684354007,
+    "wof:lastmodified":1695878772,
     "wof:name":"Schiermonnikoog",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/791/404473791.geojson
+++ b/data/404/473/791/404473791.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.113412,
     "geom:longitude":6.038961,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.114664,
     "lbl:longitude":6.038843,
     "lbl:max_zoom":14.0,
@@ -190,10 +199,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0090",
         "eg:gisco_id":"NL_GM0090",
         "eurostat:nuts_2021_id":"GM0090",
         "hasc:id":"NL.FR.SM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -209,7 +220,7 @@
         }
     ],
     "wof:id":404473791,
-    "wof:lastmodified":1684354008,
+    "wof:lastmodified":1695878773,
     "wof:name":"Smallingerland",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/795/404473795.geojson
+++ b/data/404/473/795/404473795.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.398151,
     "geom:longitude":5.330173,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.39904,
     "lbl:longitude":5.334577,
     "lbl:max_zoom":15.0,
@@ -209,10 +218,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0093",
         "eg:gisco_id":"NL_GM0093",
         "eurostat:nuts_2021_id":"GM0093",
         "hasc:id":"NL.FR.TE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -229,7 +240,7 @@
         }
     ],
     "wof:id":404473795,
-    "wof:lastmodified":1684354008,
+    "wof:lastmodified":1695878773,
     "wof:name":"Terschelling",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/799/404473799.geojson
+++ b/data/404/473/799/404473799.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.261201,
     "geom:longitude":4.976034,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.230032,
     "lbl:longitude":4.909946,
     "lbl:max_zoom":16.0,
@@ -206,10 +215,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0096",
         "eg:gisco_id":"NL_GM0096",
         "eurostat:nuts_2021_id":"GM0096",
         "hasc:id":"NL.FR.VL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -226,7 +237,7 @@
         }
     ],
     "wof:id":404473799,
-    "wof:lastmodified":1684354009,
+    "wof:lastmodified":1695878774,
     "wof:name":"Vlieland",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/801/404473801.geojson
+++ b/data/404/473/801/404473801.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":52.875741,
     "geom:longitude":6.017774,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.874862,
     "lbl:longitude":6.01451,
     "lbl:max_zoom":14.0,
@@ -178,10 +187,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0098",
         "eg:gisco_id":"NL_GM0098",
         "eurostat:nuts_2021_id":"GM0098",
         "hasc:id":"NL.FR.WE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -197,7 +208,7 @@
         }
     ],
     "wof:id":404473801,
-    "wof:lastmodified":1684354009,
+    "wof:lastmodified":1695878774,
     "wof:name":"Weststellingwerf",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/805/404473805.geojson
+++ b/data/404/473/805/404473805.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.001288,
     "geom:longitude":6.552483,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.996601,
     "lbl:longitude":6.551479,
     "lbl:max_zoom":14.0,
@@ -272,10 +281,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0106",
         "eg:gisco_id":"NL_GM0106",
         "eurostat:nuts_2021_id":"GM0106",
         "hasc:id":"NL.DR.AS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -291,7 +302,7 @@
         }
     ],
     "wof:id":404473805,
-    "wof:lastmodified":1684354009,
+    "wof:lastmodified":1695878774,
     "wof:name":"Assen",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/473/807/404473807.geojson
+++ b/data/404/473/807/404473807.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.740308,
     "geom:longitude":6.735915,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.734121,
     "lbl:longitude":6.736078,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0109",
         "eg:gisco_id":"NL_GM0109",
         "eurostat:nuts_2021_id":"GM0109",
         "hasc:id":"NL.DR.CO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404473807,
-    "wof:lastmodified":1684354009,
+    "wof:lastmodified":1695878775,
     "wof:name":"Coevorden",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/473/809/404473809.geojson
+++ b/data/404/473/809/404473809.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.749718,
     "geom:longitude":6.961985,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.7455,
     "lbl:longitude":6.964652,
     "lbl:max_zoom":14.0,
@@ -134,10 +143,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0114",
         "eg:gisco_id":"NL_GM0114",
         "eurostat:nuts_2021_id":"GM0114",
         "hasc:id":"NL.DR.EM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -153,7 +164,7 @@
         }
     ],
     "wof:id":404473809,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878775,
     "wof:name":"Emmen",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/473/811/404473811.geojson
+++ b/data/404/473/811/404473811.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.723104,
     "geom:longitude":6.513553,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.718478,
     "lbl:longitude":6.521351,
     "lbl:max_zoom":14.0,
@@ -200,10 +209,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0118",
         "eg:gisco_id":"NL_GM0118",
         "eurostat:nuts_2021_id":"GM0118",
         "hasc:id":"NL.DR.HO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -219,7 +230,7 @@
         }
     ],
     "wof:id":404473811,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878775,
     "wof:name":"Hoogeveen",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/473/813/404473813.geojson
+++ b/data/404/473/813/404473813.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.715938,
     "geom:longitude":6.193813,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.713014,
     "lbl:longitude":6.178807,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0119",
         "eg:gisco_id":"NL_GM0119",
         "eurostat:nuts_2021_id":"GM0119",
         "hasc:id":"NL.DR.ME"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404473813,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878775,
     "wof:name":"Meppel",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/473/817/404473817.geojson
+++ b/data/404/473/817/404473817.geojson
@@ -16,6 +16,15 @@
     "geom:latitude":53.125272,
     "geom:longitude":5.655227,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.119212,
     "lbl:longitude":5.645347,
     "lbl:max_zoom":15.0,
@@ -156,13 +165,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0140",
         "hasc:id":"NL.FR.LI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a3a3781d50dc418e8e1b1e7ac31b9e7",
+    "wof:geomhash":"e775961467117d7e82110a1455707928",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -173,7 +184,7 @@
         }
     ],
     "wof:id":404473817,
-    "wof:lastmodified":1582362768,
+    "wof:lastmodified":1695878759,
     "wof:name":"Littenseradiel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/473/819/404473819.geojson
+++ b/data/404/473/819/404473819.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.347902,
     "geom:longitude":6.658197,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.348125,
     "lbl:longitude":6.656985,
     "lbl:max_zoom":14.0,
@@ -212,10 +221,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0141",
         "eg:gisco_id":"NL_GM0141",
         "eurostat:nuts_2021_id":"GM0141",
         "hasc:id":"NL.OV.AL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -231,7 +242,7 @@
         }
     ],
     "wof:id":404473819,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878775,
     "wof:name":"Almelo",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/821/404473821.geojson
+++ b/data/404/473/821/404473821.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.312332,
     "geom:longitude":6.74356,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.309676,
     "lbl:longitude":6.742764,
     "lbl:max_zoom":14.0,
@@ -128,10 +137,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0147",
         "eg:gisco_id":"NL_GM0147",
         "eurostat:nuts_2021_id":"GM0147",
         "hasc:id":"NL.OV.BO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -147,7 +158,7 @@
         }
     ],
     "wof:id":404473821,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878775,
     "wof:name":"Borne",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/823/404473823.geojson
+++ b/data/404/473/823/404473823.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.514761,
     "geom:longitude":6.276648,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.527123,
     "lbl:longitude":6.265831,
     "lbl:max_zoom":14.0,
@@ -170,10 +179,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0148",
         "eg:gisco_id":"NL_GM0148",
         "eurostat:nuts_2021_id":"GM0148",
         "hasc:id":"NL.OV.DA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404473823,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878776,
     "wof:name":"Dalfsen",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/825/404473825.geojson
+++ b/data/404/473/825/404473825.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.26823,
     "geom:longitude":6.235794,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.271407,
     "lbl:longitude":6.235755,
     "lbl:max_zoom":14.0,
@@ -251,10 +260,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0150",
         "eg:gisco_id":"NL_GM0150",
         "eurostat:nuts_2021_id":"GM0150",
         "hasc:id":"NL.OV.DV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -270,7 +281,7 @@
         }
     ],
     "wof:id":404473825,
-    "wof:lastmodified":1684354010,
+    "wof:lastmodified":1695878776,
     "wof:name":"Deventer",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/827/404473827.geojson
+++ b/data/404/473/827/404473827.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.220814,
     "geom:longitude":6.877809,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.220107,
     "lbl:longitude":6.880031,
     "lbl:max_zoom":14.0,
@@ -284,10 +293,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0153",
         "eg:gisco_id":"NL_GM0153",
         "eurostat:nuts_2021_id":"GM0153",
         "hasc:id":"NL.OV.EN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -303,7 +314,7 @@
         }
     ],
     "wof:id":404473827,
-    "wof:lastmodified":1684354011,
+    "wof:lastmodified":1695878776,
     "wof:name":"Enschede",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/829/404473829.geojson
+++ b/data/404/473/829/404473829.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.155499,
     "geom:longitude":6.755841,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.157678,
     "lbl:longitude":6.745103,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0158",
         "eg:gisco_id":"NL_GM0158",
         "eurostat:nuts_2021_id":"GM0158",
         "hasc:id":"NL.OV.HK"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473829,
-    "wof:lastmodified":1684354011,
+    "wof:lastmodified":1695878776,
     "wof:name":"Haaksbergen",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/831/404473831.geojson
+++ b/data/404/473/831/404473831.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.585642,
     "geom:longitude":6.574075,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.59339,
     "lbl:longitude":6.609176,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0160",
         "eg:gisco_id":"NL_GM0160",
         "eurostat:nuts_2021_id":"GM0160",
         "hasc:id":"NL.OV.HD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473831,
-    "wof:lastmodified":1684354011,
+    "wof:lastmodified":1695878776,
     "wof:name":"Hardenberg",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/835/404473835.geojson
+++ b/data/404/473/835/404473835.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.386383,
     "geom:longitude":6.450918,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.391546,
     "lbl:longitude":6.449166,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0163",
         "eg:gisco_id":"NL_GM0163",
         "eurostat:nuts_2021_id":"GM0163",
         "hasc:id":"NL.OV.HL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473835,
-    "wof:lastmodified":1684354011,
+    "wof:lastmodified":1695878776,
     "wof:name":"Hellendoorn",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/837/404473837.geojson
+++ b/data/404/473/837/404473837.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.254918,
     "geom:longitude":6.778223,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.266649,
     "lbl:longitude":6.792247,
     "lbl:max_zoom":14.0,
@@ -215,10 +224,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0164",
         "eg:gisco_id":"NL_GM0164",
         "eurostat:nuts_2021_id":"GM0164",
         "hasc:id":"NL.OV.HN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -234,7 +245,7 @@
         }
     ],
     "wof:id":404473837,
-    "wof:lastmodified":1684354011,
+    "wof:lastmodified":1695878777,
     "wof:name":"Hengelo",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/839/404473839.geojson
+++ b/data/404/473/839/404473839.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.555606,
     "geom:longitude":5.931472,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.55464,
     "lbl:longitude":5.931875,
     "lbl:max_zoom":14.0,
@@ -127,10 +136,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0166",
         "eg:gisco_id":"NL_GM0166",
         "eurostat:nuts_2021_id":"GM0166",
         "hasc:id":"NL.OV.KA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -147,7 +158,7 @@
         }
     ],
     "wof:id":404473839,
-    "wof:lastmodified":1684354011,
+    "wof:lastmodified":1695878777,
     "wof:name":"Kampen",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/841/404473841.geojson
+++ b/data/404/473/841/404473841.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.302845,
     "geom:longitude":7.002751,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.310395,
     "lbl:longitude":6.990379,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0168",
         "eg:gisco_id":"NL_GM0168",
         "eurostat:nuts_2021_id":"GM0168",
         "hasc:id":"NL.OV.LO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404473841,
-    "wof:lastmodified":1684354012,
+    "wof:lastmodified":1695878778,
     "wof:name":"Losser",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/843/404473843.geojson
+++ b/data/404/473/843/404473843.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.712514,
     "geom:longitude":5.767525,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.715961,
     "lbl:longitude":5.753741,
     "lbl:max_zoom":14.0,
@@ -202,10 +211,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0171",
         "eg:gisco_id":"NL_GM0171",
         "eurostat:nuts_2021_id":"GM0171",
         "hasc:id":"NL.FL.NO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -222,7 +233,7 @@
         }
     ],
     "wof:id":404473843,
-    "wof:lastmodified":1684354012,
+    "wof:lastmodified":1695878778,
     "wof:name":"Noordoostpolder",
     "wof:parent_id":85687049,
     "wof:placetype":"localadmin",

--- a/data/404/473/847/404473847.geojson
+++ b/data/404/473/847/404473847.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.516144,
     "geom:longitude":6.434755,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.517393,
     "lbl:longitude":6.424909,
     "lbl:max_zoom":15.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0175",
         "eg:gisco_id":"NL_GM0175",
         "eurostat:nuts_2021_id":"GM0175",
         "hasc:id":"NL.OV.OM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473847,
-    "wof:lastmodified":1684354013,
+    "wof:lastmodified":1695878778,
     "wof:name":"Ommen",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/849/404473849.geojson
+++ b/data/404/473/849/404473849.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.387858,
     "geom:longitude":6.279019,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.374149,
     "lbl:longitude":6.281021,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0177",
         "eg:gisco_id":"NL_GM0177",
         "eurostat:nuts_2021_id":"GM0177",
         "hasc:id":"NL.OV.RA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473849,
-    "wof:lastmodified":1684354013,
+    "wof:lastmodified":1695878778,
     "wof:name":"Raalte",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/853/404473853.geojson
+++ b/data/404/473/853/404473853.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.633507,
     "geom:longitude":6.207084,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.634963,
     "lbl:longitude":6.209167,
     "lbl:max_zoom":15.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0180",
         "eg:gisco_id":"NL_GM0180",
         "eurostat:nuts_2021_id":"GM0180",
         "hasc:id":"NL.OV.SH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473853,
-    "wof:lastmodified":1684354013,
+    "wof:lastmodified":1695878779,
     "wof:name":"Staphorst",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/855/404473855.geojson
+++ b/data/404/473/855/404473855.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.410593,
     "geom:longitude":6.776674,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.409614,
     "lbl:longitude":6.75528,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0183",
         "eg:gisco_id":"NL_GM0183",
         "eurostat:nuts_2021_id":"GM0183",
         "hasc:id":"NL.OV.TU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404473855,
-    "wof:lastmodified":1684354013,
+    "wof:lastmodified":1695878779,
     "wof:name":"Tubbergen",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/859/404473859.geojson
+++ b/data/404/473/859/404473859.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.344465,
     "geom:longitude":6.560614,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.359423,
     "lbl:longitude":6.561592,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0189",
         "eg:gisco_id":"NL_GM0189",
         "eurostat:nuts_2021_id":"GM0189",
         "hasc:id":"NL.OV.WI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473859,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878779,
     "wof:name":"Wierden",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/861/404473861.geojson
+++ b/data/404/473/861/404473861.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.5187,
     "geom:longitude":6.118366,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.508699,
     "lbl:longitude":6.125301,
     "lbl:max_zoom":14.0,
@@ -302,10 +311,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0193",
         "eg:gisco_id":"NL_GM0193",
         "eurostat:nuts_2021_id":"GM0193",
         "hasc:id":"NL.OV.ZL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101751861
     ],
@@ -324,7 +335,7 @@
         }
     ],
     "wof:id":404473861,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878779,
     "wof:name":"Zwolle",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/473/863/404473863.geojson
+++ b/data/404/473/863/404473863.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":51.881353,
     "geom:longitude":6.08517,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.886939,
     "lbl:longitude":6.07622,
     "lbl:max_zoom":15.0,
@@ -142,13 +151,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0196",
         "hasc:id":"NL.GE.RI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af0dc03dba066e65c7ac169833f389dc",
+    "wof:geomhash":"954d2dfb7651042b30daaa54bebb1a0d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -159,7 +170,7 @@
         }
     ],
     "wof:id":404473863,
-    "wof:lastmodified":1582362784,
+    "wof:lastmodified":1695878761,
     "wof:name":"Rijnwaarden",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/865/404473865.geojson
+++ b/data/404/473/865/404473865.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.921747,
     "geom:longitude":6.560611,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.928147,
     "lbl:longitude":6.559185,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0197",
         "eg:gisco_id":"NL_GM0197",
         "eurostat:nuts_2021_id":"GM0197",
         "hasc:id":"NL.GE.AA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404473865,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878779,
     "wof:name":"Aalten",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/867/404473867.geojson
+++ b/data/404/473/867/404473867.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.189885,
     "geom:longitude":5.921845,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.186794,
     "lbl:longitude":5.936102,
     "lbl:max_zoom":14.0,
@@ -263,10 +272,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0200",
         "eg:gisco_id":"NL_GM0200",
         "eurostat:nuts_2021_id":"GM0200",
         "hasc:id":"NL.GE.AP"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -282,7 +293,7 @@
         }
     ],
     "wof:id":404473867,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878779,
     "wof:name":"Apeldoorn",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/871/404473871.geojson
+++ b/data/404/473/871/404473871.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.001156,
     "geom:longitude":5.892592,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.006896,
     "lbl:longitude":5.901558,
     "lbl:max_zoom":14.0,
@@ -329,10 +338,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0202",
         "eg:gisco_id":"NL_GM0202",
         "eurostat:nuts_2021_id":"GM0202",
         "hasc:id":"NL.GE.AR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -348,7 +359,7 @@
         }
     ],
     "wof:id":404473871,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878780,
     "wof:name":"Arnhem",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/873/404473873.geojson
+++ b/data/404/473/873/404473873.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.168285,
     "geom:longitude":5.641902,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.179007,
     "lbl:longitude":5.673145,
     "lbl:max_zoom":14.0,
@@ -107,10 +116,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0203",
         "eg:gisco_id":"NL_GM0203",
         "eurostat:nuts_2021_id":"GM0203",
         "hasc:id":"NL.GE.BA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -126,7 +137,7 @@
         }
     ],
     "wof:id":404473873,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878780,
     "wof:name":"Barneveld",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/875/404473875.geojson
+++ b/data/404/473/875/404473875.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.862813,
     "geom:longitude":5.74027,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.860411,
     "lbl:longitude":5.740215,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0209",
         "eg:gisco_id":"NL_GM0209",
         "eurostat:nuts_2021_id":"GM0209",
         "hasc:id":"NL.GE.BE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473875,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878780,
     "wof:name":"Beuningen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/877/404473877.geojson
+++ b/data/404/473/877/404473877.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.108975,
     "geom:longitude":6.118512,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.109833,
     "lbl:longitude":6.12701,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0213",
         "eg:gisco_id":"NL_GM0213",
         "eurostat:nuts_2021_id":"GM0213",
         "hasc:id":"NL.GE.BR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473877,
-    "wof:lastmodified":1684354014,
+    "wof:lastmodified":1695878780,
     "wof:name":"Brummen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/879/404473879.geojson
+++ b/data/404/473/879/404473879.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.938321,
     "geom:longitude":5.403656,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.926786,
     "lbl:longitude":5.36326,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0214",
         "eg:gisco_id":"NL_GM0214",
         "eurostat:nuts_2021_id":"GM0214",
         "hasc:id":"NL.GE.BU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473879,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878780,
     "wof:name":"Buren",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/881/404473881.geojson
+++ b/data/404/473/881/404473881.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.945779,
     "geom:longitude":5.210388,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.942877,
     "lbl:longitude":5.219774,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0216",
         "eg:gisco_id":"NL_GM0216",
         "eurostat:nuts_2021_id":"GM0216",
         "hasc:id":"NL.GE.CU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101808619
     ],
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404473881,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878780,
     "wof:name":"Culemborg",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/883/404473883.geojson
+++ b/data/404/473/883/404473883.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.018674,
     "geom:longitude":6.146904,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.020444,
     "lbl:longitude":6.14699,
     "lbl:max_zoom":15.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0221",
         "eg:gisco_id":"NL_GM0221",
         "eurostat:nuts_2021_id":"GM0221",
         "hasc:id":"NL.GE.DB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404473883,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878781,
     "wof:name":"Doesburg",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/885/404473885.geojson
+++ b/data/404/473/885/404473885.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.960772,
     "geom:longitude":6.286692,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.966224,
     "lbl:longitude":6.2961,
     "lbl:max_zoom":14.0,
@@ -203,10 +212,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0222",
         "eg:gisco_id":"NL_GM0222",
         "eurostat:nuts_2021_id":"GM0222",
         "hasc:id":"NL.GE.DT"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -222,7 +233,7 @@
         }
     ],
     "wof:id":404473885,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878781,
     "wof:name":"Doetinchem",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/889/404473889.geojson
+++ b/data/404/473/889/404473889.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.875013,
     "geom:longitude":5.612148,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.875082,
     "lbl:longitude":5.612561,
     "lbl:max_zoom":15.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0225",
         "eg:gisco_id":"NL_GM0225",
         "eurostat:nuts_2021_id":"GM0225",
         "hasc:id":"NL.GE.DR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473889,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878781,
     "wof:name":"Druten",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/891/404473891.geojson
+++ b/data/404/473/891/404473891.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.946553,
     "geom:longitude":6.018177,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.944414,
     "lbl:longitude":6.017087,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0226",
         "eg:gisco_id":"NL_GM0226",
         "eurostat:nuts_2021_id":"GM0226",
         "hasc:id":"NL.GE.DU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473891,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878781,
     "wof:name":"Duiven",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/893/404473893.geojson
+++ b/data/404/473/893/404473893.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.076423,
     "geom:longitude":5.728037,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.066226,
     "lbl:longitude":5.691431,
     "lbl:max_zoom":14.0,
@@ -110,10 +119,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0228",
         "eg:gisco_id":"NL_GM0228",
         "eurostat:nuts_2021_id":"GM0228",
         "hasc:id":"NL.GE.ED"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -129,7 +140,7 @@
         }
     ],
     "wof:id":404473893,
-    "wof:lastmodified":1684354015,
+    "wof:lastmodified":1695878781,
     "wof:name":"Ede",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/895/404473895.geojson
+++ b/data/404/473/895/404473895.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.411992,
     "geom:longitude":5.849976,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.413988,
     "lbl:longitude":5.851125,
     "lbl:max_zoom":14.0,
@@ -163,10 +172,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0230",
         "eg:gisco_id":"NL_GM0230",
         "eurostat:nuts_2021_id":"GM0230",
         "hasc:id":"NL.GE.EL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473895,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878781,
     "wof:name":"Elburg",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/897/404473897.geojson
+++ b/data/404/473/897/404473897.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.325519,
     "geom:longitude":5.954985,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.335135,
     "lbl:longitude":5.942549,
     "lbl:max_zoom":14.0,
@@ -77,10 +86,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0232",
         "eg:gisco_id":"NL_GM0232",
         "eurostat:nuts_2021_id":"GM0232",
         "hasc:id":"NL.GE.EP"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -96,7 +107,7 @@
         }
     ],
     "wof:id":404473897,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878782,
     "wof:name":"Epe",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/899/404473899.geojson
+++ b/data/404/473/899/404473899.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.287698,
     "geom:longitude":5.668227,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.276483,
     "lbl:longitude":5.702062,
     "lbl:max_zoom":14.0,
@@ -181,10 +190,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0233",
         "eg:gisco_id":"NL_GM0233",
         "eurostat:nuts_2021_id":"GM0233",
         "hasc:id":"NL.GE.ER"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404473899,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878782,
     "wof:name":"Ermelo",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/901/404473901.geojson
+++ b/data/404/473/901/404473901.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013282,
-    "geom:area_square_m":101363244.906378,
+    "geom:area_square_m":101363244.906376,
     "geom:bbox":"5.11427458597,51.8473043329,5.33955144792,51.9354825395",
     "geom:latitude":51.887844,
     "geom:longitude":5.220939,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.88717,
     "lbl:longitude":5.220815,
     "lbl:max_zoom":14.0,
@@ -151,13 +160,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0236",
         "hasc:id":"NL.GE.GM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2bd274ccad3462feb6f0253b5b431d4f",
+    "wof:geomhash":"330dafc1187cfb0cfff41cd3309a4149",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404473901,
-    "wof:lastmodified":1582362765,
+    "wof:lastmodified":1695878758,
     "wof:name":"Geldermalsen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/907/404473907.geojson
+++ b/data/404/473/907/404473907.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.339469,
     "geom:longitude":5.655253,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.339118,
     "lbl:longitude":5.667837,
     "lbl:max_zoom":14.0,
@@ -187,10 +196,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0243",
         "eg:gisco_id":"NL_GM0243",
         "eurostat:nuts_2021_id":"GM0243",
         "hasc:id":"NL.GE.HW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -207,7 +218,7 @@
         }
     ],
     "wof:id":404473907,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878782,
     "wof:name":"Harderwijk",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/909/404473909.geojson
+++ b/data/404/473/909/404473909.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.474784,
     "geom:longitude":6.053255,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.469055,
     "lbl:longitude":6.056641,
     "lbl:max_zoom":15.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0244",
         "eg:gisco_id":"NL_GM0244",
         "eurostat:nuts_2021_id":"GM0244",
         "hasc:id":"NL.GE.HT"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101837771
     ],
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404473909,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878782,
     "wof:name":"Hattem",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/911/404473911.geojson
+++ b/data/404/473/911/404473911.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.406062,
     "geom:longitude":6.050334,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.404571,
     "lbl:longitude":6.052134,
     "lbl:max_zoom":15.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0246",
         "eg:gisco_id":"NL_GM0246",
         "eurostat:nuts_2021_id":"GM0246",
         "hasc:id":"NL.GE.HR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473911,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878782,
     "wof:name":"Heerde",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/913/404473913.geojson
+++ b/data/404/473/913/404473913.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.777886,
     "geom:longitude":5.818494,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.783471,
     "lbl:longitude":5.844942,
     "lbl:max_zoom":15.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0252",
         "eg:gisco_id":"NL_GM0252",
         "eurostat:nuts_2021_id":"GM0252",
         "hasc:id":"NL.GE.HM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473913,
-    "wof:lastmodified":1684354016,
+    "wof:lastmodified":1695878782,
     "wof:name":"Heumen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/915/404473915.geojson
+++ b/data/404/473/915/404473915.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.179476,
     "geom:longitude":6.346806,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.185753,
     "lbl:longitude":6.377108,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0262",
         "eg:gisco_id":"NL_GM0262",
         "eurostat:nuts_2021_id":"GM0262",
         "hasc:id":"NL.GE.LO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473915,
-    "wof:lastmodified":1684354017,
+    "wof:lastmodified":1695878782,
     "wof:name":"Lochem",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/917/404473917.geojson
+++ b/data/404/473/917/404473917.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.776252,
     "geom:longitude":5.296959,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.777376,
     "lbl:longitude":5.31551,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0263",
         "eg:gisco_id":"NL_GM0263",
         "eurostat:nuts_2021_id":"GM0263",
         "hasc:id":"NL.GE.MA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473917,
-    "wof:lastmodified":1684354017,
+    "wof:lastmodified":1695878783,
     "wof:name":"Maasdriel",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/921/404473921.geojson
+++ b/data/404/473/921/404473921.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.210838,
     "geom:longitude":5.48569,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.211513,
     "lbl:longitude":5.47574,
     "lbl:max_zoom":14.0,
@@ -175,10 +184,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0267",
         "eg:gisco_id":"NL_GM0267",
         "eurostat:nuts_2021_id":"GM0267",
         "hasc:id":"NL.GE.NK"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404473921,
-    "wof:lastmodified":1684354017,
+    "wof:lastmodified":1695878783,
     "wof:name":"Nijkerk",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/925/404473925.geojson
+++ b/data/404/473/925/404473925.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.838507,
     "geom:longitude":5.836773,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.84124,
     "lbl:longitude":5.850173,
     "lbl:max_zoom":14.0,
@@ -296,10 +305,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0268",
         "eg:gisco_id":"NL_GM0268",
         "eurostat:nuts_2021_id":"GM0268",
         "hasc:id":"NL.GE.NM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -315,7 +326,7 @@
         }
     ],
     "wof:id":404473925,
-    "wof:lastmodified":1684354017,
+    "wof:lastmodified":1695878783,
     "wof:name":"Nijmegen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/927/404473927.geojson
+++ b/data/404/473/927/404473927.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.456735,
     "geom:longitude":5.937634,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.438772,
     "lbl:longitude":5.944469,
     "lbl:max_zoom":14.0,
@@ -157,10 +166,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0269",
         "eg:gisco_id":"NL_GM0269",
         "eurostat:nuts_2021_id":"GM0269",
         "hasc:id":"NL.GE.OL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473927,
-    "wof:lastmodified":1684354017,
+    "wof:lastmodified":1695878783,
     "wof:name":"Oldebroek",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/929/404473929.geojson
+++ b/data/404/473/929/404473929.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.243228,
     "geom:longitude":5.584305,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.242132,
     "lbl:longitude":5.584439,
     "lbl:max_zoom":14.0,
@@ -160,10 +169,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0273",
         "eg:gisco_id":"NL_GM0273",
         "eurostat:nuts_2021_id":"GM0273",
         "hasc:id":"NL.GE.PU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404473929,
-    "wof:lastmodified":1684354017,
+    "wof:lastmodified":1695878783,
     "wof:name":"Putten",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/931/404473931.geojson
+++ b/data/404/473/931/404473931.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.989618,
     "geom:longitude":5.784843,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.991237,
     "lbl:longitude":5.775453,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0274",
         "eg:gisco_id":"NL_GM0274",
         "eurostat:nuts_2021_id":"GM0274",
         "hasc:id":"NL.GE.RE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473931,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878784,
     "wof:name":"Renkum",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/933/404473933.geojson
+++ b/data/404/473/933/404473933.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.033546,
     "geom:longitude":6.051269,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.051292,
     "lbl:longitude":6.066488,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0275",
         "eg:gisco_id":"NL_GM0275",
         "eurostat:nuts_2021_id":"GM0275",
         "hasc:id":"NL.GE.RH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473933,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878784,
     "wof:name":"Rheden",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/935/404473935.geojson
+++ b/data/404/473/935/404473935.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.042546,
     "geom:longitude":5.967898,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.037701,
     "lbl:longitude":5.96091,
     "lbl:max_zoom":16.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0277",
         "eg:gisco_id":"NL_GM0277",
         "eurostat:nuts_2021_id":"GM0277",
         "hasc:id":"NL.GE.RO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101754767
     ],
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473935,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878784,
     "wof:name":"Rozendaal",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/937/404473937.geojson
+++ b/data/404/473/937/404473937.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.089324,
     "geom:longitude":5.500493,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.091513,
     "lbl:longitude":5.500879,
     "lbl:max_zoom":15.0,
@@ -86,10 +95,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0279",
         "eg:gisco_id":"NL_GM0279",
         "eurostat:nuts_2021_id":"GM0279",
         "hasc:id":"NL.GE.SC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101807121
     ],
@@ -108,7 +119,7 @@
         }
     ],
     "wof:id":404473937,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878784,
     "wof:name":"Scherpenzeel",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/939/404473939.geojson
+++ b/data/404/473/939/404473939.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.885084,
     "geom:longitude":5.406879,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.876076,
     "lbl:longitude":5.399865,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0281",
         "eg:gisco_id":"NL_GM0281",
         "eurostat:nuts_2021_id":"GM0281",
         "hasc:id":"NL.GE.TI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404473939,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878784,
     "wof:name":"Tiel",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/945/404473945.geojson
+++ b/data/404/473/945/404473945.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.225605,
     "geom:longitude":6.099081,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.220595,
     "lbl:longitude":6.093419,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0285",
         "eg:gisco_id":"NL_GM0285",
         "eurostat:nuts_2021_id":"GM0285",
         "hasc:id":"NL.GE.VS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404473945,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878784,
     "wof:name":"Voorst",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/947/404473947.geojson
+++ b/data/404/473/947/404473947.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.973477,
     "geom:longitude":5.663516,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.97374,
     "lbl:longitude":5.662625,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0289",
         "eg:gisco_id":"NL_GM0289",
         "eurostat:nuts_2021_id":"GM0289",
         "hasc:id":"NL.GE.WG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101837813
     ],
@@ -207,7 +218,7 @@
         }
     ],
     "wof:id":404473947,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878785,
     "wof:name":"Wageningen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/949/404473949.geojson
+++ b/data/404/473/949/404473949.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.95752,
     "geom:longitude":5.970719,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.957042,
     "lbl:longitude":5.970754,
     "lbl:max_zoom":15.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0293",
         "eg:gisco_id":"NL_GM0293",
         "eurostat:nuts_2021_id":"GM0293",
         "hasc:id":"NL.GE.WV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101837821
     ],
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473949,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878785,
     "wof:name":"Westervoort",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/951/404473951.geojson
+++ b/data/404/473/951/404473951.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.969869,
     "geom:longitude":6.725866,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.972383,
     "lbl:longitude":6.723861,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0294",
         "eg:gisco_id":"NL_GM0294",
         "eurostat:nuts_2021_id":"GM0294",
         "hasc:id":"NL.GE.WW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473951,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878785,
     "wof:name":"Winterswijk",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/953/404473953.geojson
+++ b/data/404/473/953/404473953.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.816736,
     "geom:longitude":5.70189,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.806979,
     "lbl:longitude":5.71869,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0296",
         "eg:gisco_id":"NL_GM0296",
         "eurostat:nuts_2021_id":"GM0296",
         "hasc:id":"NL.GE.WC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404473953,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878785,
     "wof:name":"Wijchen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/955/404473955.geojson
+++ b/data/404/473/955/404473955.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.79228,
     "geom:longitude":5.158429,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.785719,
     "lbl:longitude":5.160966,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0297",
         "eg:gisco_id":"NL_GM0297",
         "eurostat:nuts_2021_id":"GM0297",
         "hasc:id":"NL.GE.ZA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473955,
-    "wof:lastmodified":1684354018,
+    "wof:lastmodified":1695878786,
     "wof:name":"Zaltbommel",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/957/404473957.geojson
+++ b/data/404/473/957/404473957.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.959582,
     "geom:longitude":6.085255,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.954776,
     "lbl:longitude":6.076781,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0299",
         "eg:gisco_id":"NL_GM0299",
         "eurostat:nuts_2021_id":"GM0299",
         "hasc:id":"NL.GE.ZV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404473957,
-    "wof:lastmodified":1684354019,
+    "wof:lastmodified":1695878786,
     "wof:name":"Zevenaar",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/961/404473961.geojson
+++ b/data/404/473/961/404473961.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.136343,
     "geom:longitude":6.233945,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.130775,
     "lbl:longitude":6.224161,
     "lbl:max_zoom":14.0,
@@ -197,10 +206,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0301",
         "eg:gisco_id":"NL_GM0301",
         "eurostat:nuts_2021_id":"GM0301",
         "hasc:id":"NL.GE.ZU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -216,7 +227,7 @@
         }
     ],
     "wof:id":404473961,
-    "wof:lastmodified":1684354019,
+    "wof:lastmodified":1695878786,
     "wof:name":"Zutphen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/963/404473963.geojson
+++ b/data/404/473/963/404473963.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.338978,
     "geom:longitude":5.786579,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.340445,
     "lbl:longitude":5.798493,
     "lbl:max_zoom":14.0,
@@ -154,10 +163,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0302",
         "eg:gisco_id":"NL_GM0302",
         "eurostat:nuts_2021_id":"GM0302",
         "hasc:id":"NL.GE.NU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473963,
-    "wof:lastmodified":1684354019,
+    "wof:lastmodified":1695878786,
     "wof:name":"Nunspeet",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/965/404473965.geojson
+++ b/data/404/473/965/404473965.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.50233,
     "geom:longitude":5.701783,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.499619,
     "lbl:longitude":5.699595,
     "lbl:max_zoom":14.0,
@@ -202,10 +211,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0303",
         "eg:gisco_id":"NL_GM0303",
         "eurostat:nuts_2021_id":"GM0303",
         "hasc:id":"NL.FL.DR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -222,7 +233,7 @@
         }
     ],
     "wof:id":404473965,
-    "wof:lastmodified":1684354019,
+    "wof:lastmodified":1695878786,
     "wof:name":"Dronten",
     "wof:parent_id":85687049,
     "wof:placetype":"localadmin",

--- a/data/404/473/967/404473967.geojson
+++ b/data/404/473/967/404473967.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009507,
-    "geom:area_square_m":72642707.709141,
+    "geom:area_square_m":72642707.709144,
     "geom:bbox":"5.15251634463,51.8039626127,5.41523417799,51.8633999328",
     "geom:latitude":51.835367,
     "geom:longitude":5.282895,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.837981,
     "lbl:longitude":5.272263,
     "lbl:max_zoom":15.0,
@@ -142,13 +151,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0304",
         "hasc:id":"NL.GE.NR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9de58cb7cae68cd775478284e090f327",
+    "wof:geomhash":"8a332786d808644c332c1485822688c1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -159,7 +170,7 @@
         }
     ],
     "wof:id":404473967,
-    "wof:lastmodified":1582362776,
+    "wof:lastmodified":1695878760,
     "wof:name":"Neerijnen",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/473/971/404473971.geojson
+++ b/data/404/473/971/404473971.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.173656,
     "geom:longitude":5.384698,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.169219,
     "lbl:longitude":5.384786,
     "lbl:max_zoom":14.0,
@@ -275,10 +284,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0307",
         "eg:gisco_id":"NL_GM0307",
         "eurostat:nuts_2021_id":"GM0307",
         "hasc:id":"NL.UT.AF"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -294,7 +305,7 @@
         }
     ],
     "wof:id":404473971,
-    "wof:lastmodified":1684354020,
+    "wof:lastmodified":1695878787,
     "wof:name":"Amersfoort",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/973/404473973.geojson
+++ b/data/404/473/973/404473973.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.203834,
     "geom:longitude":5.264153,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.203568,
     "lbl:longitude":5.259768,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0308",
         "eg:gisco_id":"NL_GM0308",
         "eurostat:nuts_2021_id":"GM0308",
         "hasc:id":"NL.UT.BA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404473973,
-    "wof:lastmodified":1684354020,
+    "wof:lastmodified":1695878787,
     "wof:name":"Baarn",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/975/404473975.geojson
+++ b/data/404/473/975/404473975.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.141741,
     "geom:longitude":5.174306,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.141859,
     "lbl:longitude":5.179011,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0310",
         "eg:gisco_id":"NL_GM0310",
         "eurostat:nuts_2021_id":"GM0310",
         "hasc:id":"NL.UT.DB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404473975,
-    "wof:lastmodified":1684354020,
+    "wof:lastmodified":1695878787,
     "wof:name":"De Bilt",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/981/404473981.geojson
+++ b/data/404/473/981/404473981.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.040921,
     "geom:longitude":5.216923,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.036911,
     "lbl:longitude":5.223019,
     "lbl:max_zoom":15.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0312",
         "eg:gisco_id":"NL_GM0312",
         "eurostat:nuts_2021_id":"GM0312",
         "hasc:id":"NL.UT.BK"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404473981,
-    "wof:lastmodified":1684354020,
+    "wof:lastmodified":1695878788,
     "wof:name":"Bunnik",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/983/404473983.geojson
+++ b/data/404/473/983/404473983.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.238682,
     "geom:longitude":5.35797,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.239506,
     "lbl:longitude":5.358864,
     "lbl:max_zoom":14.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0313",
         "eg:gisco_id":"NL_GM0313",
         "eurostat:nuts_2021_id":"GM0313",
         "hasc:id":"NL.UT.BS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404473983,
-    "wof:lastmodified":1684354020,
+    "wof:lastmodified":1695878788,
     "wof:name":"Bunschoten",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/987/404473987.geojson
+++ b/data/404/473/987/404473987.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.004102,
     "geom:longitude":5.181698,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.004042,
     "lbl:longitude":5.17402,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0321",
         "eg:gisco_id":"NL_GM0321",
         "eurostat:nuts_2021_id":"GM0321",
         "hasc:id":"NL.UT.HO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404473987,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878788,
     "wof:name":"Houten",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/989/404473989.geojson
+++ b/data/404/473/989/404473989.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.12222,
     "geom:longitude":5.416462,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.12715,
     "lbl:longitude":5.426635,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0327",
         "eg:gisco_id":"NL_GM0327",
         "eurostat:nuts_2021_id":"GM0327",
         "hasc:id":"NL.UT.LD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404473989,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878788,
     "wof:name":"Leusden",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/993/404473993.geojson
+++ b/data/404/473/993/404473993.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.985353,
     "geom:longitude":4.945542,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.989684,
     "lbl:longitude":4.956886,
     "lbl:max_zoom":15.0,
@@ -146,10 +155,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0331",
         "eg:gisco_id":"NL_GM0331",
         "eurostat:nuts_2021_id":"GM0331",
         "hasc:id":"NL.UT.LP"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -165,7 +176,7 @@
         }
     ],
     "wof:id":404473993,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878788,
     "wof:name":"Lopik",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/473/999/404473999.geojson
+++ b/data/404/473/999/404473999.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.047711,
     "geom:longitude":4.944045,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.045551,
     "lbl:longitude":4.945138,
     "lbl:max_zoom":15.0,
@@ -149,10 +158,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0335",
         "eg:gisco_id":"NL_GM0335",
         "eurostat:nuts_2021_id":"GM0335",
         "hasc:id":"NL.UT.MO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404473999,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878788,
     "wof:name":"Montfoort",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/003/404474003.geojson
+++ b/data/404/474/003/404474003.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.980767,
     "geom:longitude":5.560516,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.978796,
     "lbl:longitude":5.560183,
     "lbl:max_zoom":15.0,
@@ -146,10 +155,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0340",
         "eg:gisco_id":"NL_GM0340",
         "eurostat:nuts_2021_id":"GM0340",
         "hasc:id":"NL.UT.RH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101809835
     ],
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474003,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878789,
     "wof:name":"Rhenen",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/005/404474005.geojson
+++ b/data/404/474/005/404474005.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.156198,
     "geom:longitude":5.296289,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.155029,
     "lbl:longitude":5.297305,
     "lbl:max_zoom":14.0,
@@ -122,10 +131,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0342",
         "eg:gisco_id":"NL_GM0342",
         "eurostat:nuts_2021_id":"GM0342",
         "hasc:id":"NL.UT.SO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101808443
     ],
@@ -144,7 +155,7 @@
         }
     ],
     "wof:id":404474005,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878789,
     "wof:name":"Soest",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/015/404474015.geojson
+++ b/data/404/474/015/404474015.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.989201,
     "geom:longitude":5.325256,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.989356,
     "lbl:longitude":5.323833,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0352",
         "eg:gisco_id":"NL_GM0352",
         "eurostat:nuts_2021_id":"GM0352",
         "hasc:id":"NL.UT.WD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474015,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878789,
     "wof:name":"Wijk bij Duurstede",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/019/404474019.geojson
+++ b/data/404/474/019/404474019.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.101976,
     "geom:longitude":5.255182,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.097983,
     "lbl:longitude":5.25422,
     "lbl:max_zoom":14.0,
@@ -194,10 +203,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0355",
         "eg:gisco_id":"NL_GM0355",
         "eurostat:nuts_2021_id":"GM0355",
         "hasc:id":"NL.UT.ZE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -213,7 +224,7 @@
         }
     ],
     "wof:id":404474019,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878789,
     "wof:name":"Zeist",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/023/404474023.geojson
+++ b/data/404/474/023/404474023.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.2577,
     "geom:longitude":4.755048,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.250607,
     "lbl:longitude":4.748852,
     "lbl:max_zoom":14.0,
@@ -215,10 +224,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0358",
         "eg:gisco_id":"NL_GM0358",
         "eurostat:nuts_2021_id":"GM0358",
         "hasc:id":"NL.NH.AA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -234,7 +245,7 @@
         }
     ],
     "wof:id":404474023,
-    "wof:lastmodified":1684354021,
+    "wof:lastmodified":1695878789,
     "wof:name":"Aalsmeer",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/025/404474025.geojson
+++ b/data/404/474/025/404474025.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.60181,
     "geom:longitude":4.803289,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.637361,
     "lbl:longitude":4.751988,
     "lbl:max_zoom":14.0,
@@ -269,10 +278,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0361",
         "eg:gisco_id":"NL_GM0361",
         "eurostat:nuts_2021_id":"GM0361",
         "hasc:id":"NL.NH.AL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -288,7 +299,7 @@
         }
     ],
     "wof:id":404474025,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878789,
     "wof:name":"Alkmaar",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/039/404474039.geojson
+++ b/data/404/474/039/404474039.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.557702,
     "geom:longitude":4.916892,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.557155,
     "lbl:longitude":4.918156,
     "lbl:max_zoom":15.0,
@@ -203,10 +212,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0370",
         "eg:gisco_id":"NL_GM0370",
         "eurostat:nuts_2021_id":"GM0370",
         "hasc:id":"NL.NH.BM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -222,7 +233,7 @@
         }
     ],
     "wof:id":404474039,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878789,
     "wof:name":"Beemster",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/041/404474041.geojson
+++ b/data/404/474/041/404474041.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.662816,
     "geom:longitude":4.670624,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.668974,
     "lbl:longitude":4.675277,
     "lbl:max_zoom":14.0,
@@ -69,9 +78,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0373",
         "eg:gisco_id":"NL_GM0373",
         "eurostat:nuts_2021_id":"GM0373"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -88,7 +99,7 @@
         }
     ],
     "wof:id":404474041,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878789,
     "wof:name":"Bergen (NH.)",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/043/404474043.geojson
+++ b/data/404/474/043/404474043.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.484067,
     "geom:longitude":4.654,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.485633,
     "lbl:longitude":4.665416,
     "lbl:max_zoom":14.0,
@@ -184,10 +193,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0375",
         "eg:gisco_id":"NL_GM0375",
         "eurostat:nuts_2021_id":"GM0375",
         "hasc:id":"NL.NH.BV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474043,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878790,
     "wof:name":"Beverwijk",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/047/404474047.geojson
+++ b/data/404/474/047/404474047.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.381829,
     "geom:longitude":4.585965,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.413964,
     "lbl:longitude":4.582823,
     "lbl:max_zoom":14.0,
@@ -184,10 +193,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0377",
         "eg:gisco_id":"NL_GM0377",
         "eurostat:nuts_2021_id":"GM0377",
         "hasc:id":"NL.NH.BL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474047,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878790,
     "wof:name":"Bloemendaal",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/053/404474053.geojson
+++ b/data/404/474/053/404474053.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.556983,
     "geom:longitude":4.68301,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.558521,
     "lbl:longitude":4.672248,
     "lbl:max_zoom":14.0,
@@ -184,10 +193,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0383",
         "eg:gisco_id":"NL_GM0383",
         "eurostat:nuts_2021_id":"GM0383",
         "hasc:id":"NL.NH.CA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474053,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878790,
     "wof:name":"Castricum",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/057/404474057.geojson
+++ b/data/404/474/057/404474057.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.541391,
     "geom:longitude":5.018898,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.503375,
     "lbl:longitude":5.044025,
     "lbl:max_zoom":14.0,
@@ -190,10 +199,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0385",
         "eg:gisco_id":"NL_GM0385",
         "eurostat:nuts_2021_id":"GM0385",
         "hasc:id":"NL.NH.EV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -210,7 +221,7 @@
         }
     ],
     "wof:id":404474057,
-    "wof:lastmodified":1684354022,
+    "wof:lastmodified":1695878790,
     "wof:name":"Edam-Volendam",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/059/404474059.geojson
+++ b/data/404/474/059/404474059.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001773,
-    "geom:area_square_m":13276888.506019,
+    "geom:area_square_m":13276888.506021,
     "geom:bbox":"5.21812746657,52.6839184646,5.30778762698,52.8054930085",
     "geom:latitude":52.718348,
     "geom:longitude":5.272079,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.715822,
     "lbl:longitude":5.271571,
     "lbl:max_zoom":15.0,
@@ -186,14 +195,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0388",
         "hasc:id":"NL.NH.EN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
         "mz"
     ],
-    "wof:geomhash":"89ac8f21a2a0952fc39144413158d724",
+    "wof:geomhash":"894409ad5b60550505886186fc02265c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474059,
-    "wof:lastmodified":1582362845,
+    "wof:lastmodified":1695878769,
     "wof:name":"Enkhuizen",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/061/404474061.geojson
+++ b/data/404/474/061/404474061.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.383416,
     "geom:longitude":4.647533,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.385346,
     "lbl:longitude":4.64824,
     "lbl:max_zoom":14.0,
@@ -317,10 +326,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0392",
         "eg:gisco_id":"NL_GM0392",
         "eurostat:nuts_2021_id":"GM0392",
         "hasc:id":"NL.NH.HA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101751897
     ],
@@ -339,7 +350,7 @@
         }
     ],
     "wof:id":404474061,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878790,
     "wof:name":"Haarlem",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/063/404474063.geojson
+++ b/data/404/474/063/404474063.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":52.402968,
     "geom:longitude":4.712453,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.404533,
     "lbl:longitude":4.708248,
     "lbl:max_zoom":15.0,
@@ -163,13 +172,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0393",
         "hasc:id":"NL.NH.HS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f586f31b8ec13ce694db45e41c0b78a",
+    "wof:geomhash":"b837a627af3a5b044e4a4a387c069416",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474063,
-    "wof:lastmodified":1582362819,
+    "wof:lastmodified":1695878766,
     "wof:name":"Haarlemmerliede en Spaarnwoude",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/065/404474065.geojson
+++ b/data/404/474/065/404474065.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.297242,
     "geom:longitude":4.683551,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.296288,
     "lbl:longitude":4.68166,
     "lbl:max_zoom":14.0,
@@ -224,10 +233,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0394",
         "eg:gisco_id":"NL_GM0394",
         "eurostat:nuts_2021_id":"GM0394",
         "hasc:id":"NL.NH.HM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -243,7 +254,7 @@
         }
     ],
     "wof:id":404474065,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878790,
     "wof:name":"Haarlemmermeer",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/073/404474073.geojson
+++ b/data/404/474/073/404474073.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.344781,
     "geom:longitude":4.615362,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.347007,
     "lbl:longitude":4.615125,
     "lbl:max_zoom":14.0,
@@ -188,10 +197,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0397",
         "eg:gisco_id":"NL_GM0397",
         "eurostat:nuts_2021_id":"GM0397",
         "hasc:id":"NL.NH.HE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101754813
     ],
@@ -210,7 +221,7 @@
         }
     ],
     "wof:id":404474073,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Heemstede",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/075/404474075.geojson
+++ b/data/404/474/075/404474075.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.676017,
     "geom:longitude":4.844598,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.67852,
     "lbl:longitude":4.850307,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0398",
         "eg:gisco_id":"NL_GM0398",
         "eurostat:nuts_2021_id":"GM0398",
         "hasc:id":"NL.NH.HH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474075,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Heerhugowaard",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/079/404474079.geojson
+++ b/data/404/474/079/404474079.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.922631,
     "geom:longitude":4.754151,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.922322,
     "lbl:longitude":4.754017,
     "lbl:max_zoom":14.0,
@@ -223,10 +232,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0400",
         "eg:gisco_id":"NL_GM0400",
         "eurostat:nuts_2021_id":"GM0400",
         "hasc:id":"NL.NH.DH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -243,7 +254,7 @@
         }
     ],
     "wof:id":404474079,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Den Helder",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/083/404474083.geojson
+++ b/data/404/474/083/404474083.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002773,
-    "geom:area_square_m":20800766.835857,
+    "geom:area_square_m":20800766.835861,
     "geom:bbox":"5.01353664744,52.6299169513,5.11941404181,52.6843654801",
     "geom:latitude":52.656151,
     "geom:longitude":5.070045,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.659395,
     "lbl:longitude":5.07748,
     "lbl:max_zoom":14.0,
@@ -216,14 +225,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0405",
         "hasc:id":"NL.NH.HO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"6be6b987d26f19a177ad48b4e7cfa7cb",
+    "wof:geomhash":"92b280fc6bf957cfa5dec9c0f6ac3ad9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +245,7 @@
         }
     ],
     "wof:id":404474083,
-    "wof:lastmodified":1582362807,
+    "wof:lastmodified":1695878763,
     "wof:name":"Hoorn",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/091/404474091.geojson
+++ b/data/404/474/091/404474091.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.450591,
     "geom:longitude":4.924555,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.449713,
     "lbl:longitude":4.921678,
     "lbl:max_zoom":15.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0415",
         "eg:gisco_id":"NL_GM0415",
         "eurostat:nuts_2021_id":"GM0415",
         "hasc:id":"NL.NH.LM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474091,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Landsmeer",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/093/404474093.geojson
+++ b/data/404/474/093/404474093.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.69124,
     "geom:longitude":4.789432,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.693732,
     "lbl:longitude":4.794642,
     "lbl:max_zoom":14.0,
@@ -182,10 +191,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0416",
         "eg:gisco_id":"NL_GM0416",
         "eurostat:nuts_2021_id":"GM0416",
         "hasc:id":"NL.NH.LD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404474093,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Langedijk",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/097/404474097.geojson
+++ b/data/404/474/097/404474097.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016787,
-    "geom:area_square_m":125724804.13796,
+    "geom:area_square_m":125724804.13797,
     "geom:bbox":"4.97188814401,52.6644029635,5.27200590176,52.7746714807",
     "geom:latitude":52.720778,
     "geom:longitude":5.099208,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.713772,
     "lbl:longitude":5.051953,
     "lbl:max_zoom":14.0,
@@ -168,14 +177,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0420",
         "hasc:id":"NL.NH.ME"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"36520caa181f7229eb66ea164eae0098",
+    "wof:geomhash":"c54d4e1d2b713328c5506f72043d91af",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474097,
-    "wof:lastmodified":1582362819,
+    "wof:lastmodified":1695878766,
     "wof:name":"Medemblik",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/105/404474105.geojson
+++ b/data/404/474/105/404474105.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.451967,
     "geom:longitude":4.87611,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.450416,
     "lbl:longitude":4.872927,
     "lbl:max_zoom":15.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0431",
         "eg:gisco_id":"NL_GM0431",
         "eurostat:nuts_2021_id":"GM0431",
         "hasc:id":"NL.NH.OO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101754851
     ],
@@ -207,7 +218,7 @@
         }
     ],
     "wof:id":404474105,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Oostzaan",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/107/404474107.geojson
+++ b/data/404/474/107/404474107.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.715288,
     "geom:longitude":4.95348,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.711279,
     "lbl:longitude":4.943159,
     "lbl:max_zoom":15.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0432",
         "eg:gisco_id":"NL_GM0432",
         "eurostat:nuts_2021_id":"GM0432",
         "hasc:id":"NL.NH.OP"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474107,
-    "wof:lastmodified":1684354023,
+    "wof:lastmodified":1695878791,
     "wof:name":"Opmeer",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/109/404474109.geojson
+++ b/data/404/474/109/404474109.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.289386,
     "geom:longitude":4.913526,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.276379,
     "lbl:longitude":4.903594,
     "lbl:max_zoom":15.0,
@@ -182,10 +191,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0437",
         "eg:gisco_id":"NL_GM0437",
         "eurostat:nuts_2021_id":"GM0437",
         "hasc:id":"NL.NH.OA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404474109,
-    "wof:lastmodified":1684354024,
+    "wof:lastmodified":1695878791,
     "wof:name":"Ouder-Amstel",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/113/404474113.geojson
+++ b/data/404/474/113/404474113.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.784324,
     "geom:longitude":4.748477,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.786768,
     "lbl:longitude":4.795588,
     "lbl:max_zoom":14.0,
@@ -178,10 +187,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0441",
         "eg:gisco_id":"NL_GM0441",
         "eurostat:nuts_2021_id":"GM0441",
         "hasc:id":"NL.NH.SN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474113,
-    "wof:lastmodified":1684354024,
+    "wof:lastmodified":1695878792,
     "wof:name":"Schagen",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/115/404474115.geojson
+++ b/data/404/474/115/404474115.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.07828,
     "geom:longitude":4.804973,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.080495,
     "lbl:longitude":4.811186,
     "lbl:max_zoom":15.0,
@@ -238,10 +247,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0448",
         "eg:gisco_id":"NL_GM0448",
         "eurostat:nuts_2021_id":"GM0448",
         "hasc:id":"NL.NH.TE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -258,7 +269,7 @@
         }
     ],
     "wof:id":404474115,
-    "wof:lastmodified":1684354024,
+    "wof:lastmodified":1695878792,
     "wof:name":"Texel",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/117/404474117.geojson
+++ b/data/404/474/117/404474117.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.52343,
     "geom:longitude":4.728609,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.52301,
     "lbl:longitude":4.727952,
     "lbl:max_zoom":15.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0450",
         "eg:gisco_id":"NL_GM0450",
         "eurostat:nuts_2021_id":"GM0450",
         "hasc:id":"NL.NH.UG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101754853
     ],
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404474117,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Uitgeest",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/119/404474119.geojson
+++ b/data/404/474/119/404474119.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.236908,
     "geom:longitude":4.790856,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.243359,
     "lbl:longitude":4.797373,
     "lbl:max_zoom":14.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0451",
         "eg:gisco_id":"NL_GM0451",
         "eurostat:nuts_2021_id":"GM0451",
         "hasc:id":"NL.NH.UH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474119,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Uithoorn",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/123/404474123.geojson
+++ b/data/404/474/123/404474123.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.4494,
     "geom:longitude":4.630517,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.449542,
     "lbl:longitude":4.63214,
     "lbl:max_zoom":14.0,
@@ -193,10 +202,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0453",
         "eg:gisco_id":"NL_GM0453",
         "eurostat:nuts_2021_id":"GM0453",
         "hasc:id":"NL.NH.VL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -213,7 +224,7 @@
         }
     ],
     "wof:id":404474123,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Velsen",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/135/404474135.geojson
+++ b/data/404/474/135/404474135.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.357998,
     "geom:longitude":4.543578,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.357973,
     "lbl:longitude":4.54329,
     "lbl:max_zoom":15.0,
@@ -196,10 +205,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0473",
         "eg:gisco_id":"NL_GM0473",
         "eurostat:nuts_2021_id":"GM0473",
         "hasc:id":"NL.NH.ZD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101808813
     ],
@@ -219,7 +230,7 @@
         }
     ],
     "wof:id":404474135,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Zandvoort",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/143/404474143.geojson
+++ b/data/404/474/143/404474143.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.462913,
     "geom:longitude":4.773002,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.465004,
     "lbl:longitude":4.766778,
     "lbl:max_zoom":14.0,
@@ -224,10 +233,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0479",
         "eg:gisco_id":"NL_GM0479",
         "eurostat:nuts_2021_id":"GM0479",
         "hasc:id":"NL.NH.ZS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -243,7 +254,7 @@
         }
     ],
     "wof:id":404474143,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Zaanstad",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/145/404474145.geojson
+++ b/data/404/474/145/404474145.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.864655,
     "geom:longitude":4.665727,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.860973,
     "lbl:longitude":4.668194,
     "lbl:max_zoom":15.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0482",
         "eg:gisco_id":"NL_GM0482",
         "eurostat:nuts_2021_id":"GM0482",
         "hasc:id":"NL.ZH.AS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101754613
     ],
@@ -207,7 +218,7 @@
         }
     ],
     "wof:id":404474145,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Alblasserdam",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/147/404474147.geojson
+++ b/data/404/474/147/404474147.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.113323,
     "geom:longitude":4.640979,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.130597,
     "lbl:longitude":4.674371,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0484",
         "eg:gisco_id":"NL_GM0484",
         "eurostat:nuts_2021_id":"GM0484",
         "hasc:id":"NL.ZH.AR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474147,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878793,
     "wof:name":"Alphen aan den Rijn",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/155/404474155.geojson
+++ b/data/404/474/155/404474155.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.663939,
     "geom:longitude":5.164986,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.664355,
     "lbl:longitude":5.164813,
     "lbl:max_zoom":15.0,
@@ -181,10 +190,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0498",
         "eg:gisco_id":"NL_GM0498",
         "eurostat:nuts_2021_id":"GM0498",
         "hasc:id":"NL.NH.DR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404474155,
-    "wof:lastmodified":1684354025,
+    "wof:lastmodified":1695878794,
     "wof:name":"Drechterland",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/161/404474161.geojson
+++ b/data/404/474/161/404474161.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.888694,
     "geom:longitude":4.184475,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.887632,
     "lbl:longitude":4.184773,
     "lbl:max_zoom":15.0,
@@ -182,10 +191,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0501",
         "eg:gisco_id":"NL_GM0501",
         "eurostat:nuts_2021_id":"GM0501",
         "hasc:id":"NL.ZH.BL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404474161,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Brielle",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/173/404474173.geojson
+++ b/data/404/474/173/404474173.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.838459,
     "geom:longitude":4.977078,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.843036,
     "lbl:longitude":4.96435,
     "lbl:max_zoom":14.0,
@@ -191,10 +200,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0512",
         "eg:gisco_id":"NL_GM0512",
         "eurostat:nuts_2021_id":"GM0512",
         "hasc:id":"NL.ZH.GC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101808515
     ],
@@ -213,7 +224,7 @@
         }
     ],
     "wof:id":404474173,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Gorinchem",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/181/404474181.geojson
+++ b/data/404/474/181/404474181.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.832612,
     "geom:longitude":4.85242,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.837641,
     "lbl:longitude":4.827389,
     "lbl:max_zoom":15.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0523",
         "eg:gisco_id":"NL_GM0523",
         "eurostat:nuts_2021_id":"GM0523",
         "hasc:id":"NL.ZH.HG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474181,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Hardinxveld-Giessendam",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/183/404474183.geojson
+++ b/data/404/474/183/404474183.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.846507,
     "geom:longitude":4.137437,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.847618,
     "lbl:longitude":4.142519,
     "lbl:max_zoom":14.0,
@@ -169,10 +178,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0530",
         "eg:gisco_id":"NL_GM0530",
         "eurostat:nuts_2021_id":"GM0530",
         "hasc:id":"NL.ZH.HV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101808501
     ],
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474183,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Hellevoetsluis",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/187/404474187.geojson
+++ b/data/404/474/187/404474187.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.70098,
     "geom:longitude":5.225218,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.701514,
     "lbl:longitude":5.225311,
     "lbl:max_zoom":14.0,
@@ -178,10 +187,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0532",
         "eg:gisco_id":"NL_GM0532",
         "eurostat:nuts_2021_id":"GM0532",
         "hasc:id":"NL.NH.SB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474187,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Stede Broec",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/191/404474191.geojson
+++ b/data/404/474/191/404474191.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.189685,
     "geom:longitude":4.422672,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.193421,
     "lbl:longitude":4.418434,
     "lbl:max_zoom":14.0,
@@ -199,10 +208,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0537",
         "eg:gisco_id":"NL_GM0537",
         "eurostat:nuts_2021_id":"GM0537",
         "hasc:id":"NL.ZH.KA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -219,7 +230,7 @@
         }
     ],
     "wof:id":404474191,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Katwijk",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/197/404474197.geojson
+++ b/data/404/474/197/404474197.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004496,
-    "geom:area_square_m":34298319.69583,
+    "geom:area_square_m":34298319.695831,
     "geom:bbox":"5.02174888725,51.8573606843,5.14943744237,51.9461260974",
     "geom:latitude":51.902849,
     "geom:longitude":5.085934,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.910834,
     "lbl:longitude":5.10053,
     "lbl:max_zoom":14.0,
@@ -148,13 +157,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0545",
         "hasc:id":"NL.ZH.LR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"253c6654467953a5c8577611a4077c63",
+    "wof:geomhash":"1bb1c10d10f1d6a039fb03153237ee60",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +176,7 @@
         }
     ],
     "wof:id":404474197,
-    "wof:lastmodified":1582362832,
+    "wof:lastmodified":1695878768,
     "wof:name":"Leerdam",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/217/404474217.geojson
+++ b/data/404/474/217/404474217.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.170791,
     "geom:longitude":4.779458,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.17201,
     "lbl:longitude":4.779376,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0569",
         "eg:gisco_id":"NL_GM0569",
         "eurostat:nuts_2021_id":"GM0569",
         "hasc:id":"NL.ZH.NK"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474217,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878794,
     "wof:name":"Nieuwkoop",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/221/404474221.geojson
+++ b/data/404/474/221/404474221.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004731,
-    "geom:area_square_m":35796772.779724,
+    "geom:area_square_m":35796772.77972,
     "geom:bbox":"4.40546408224,52.2073555838,4.54337082268,52.3282278471",
     "geom:latitude":52.268622,
     "geom:longitude":4.470801,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.303909,
     "lbl:longitude":4.500034,
     "lbl:max_zoom":14.0,
@@ -171,14 +180,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0575",
         "hasc:id":"NL.ZH.NW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
         "mz"
     ],
-    "wof:geomhash":"490b2a601f0f619f506f5e6ce4b50f31",
+    "wof:geomhash":"554f63ab6d0fb199623b3a1876c67f91",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474221,
-    "wof:lastmodified":1582362807,
+    "wof:lastmodified":1695878763,
     "wof:name":"Noordwijk",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/223/404474223.geojson
+++ b/data/404/474/223/404474223.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.271465,
     "geom:longitude":4.505973,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.268366,
     "lbl:longitude":4.506811,
     "lbl:max_zoom":15.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0576",
         "eg:gisco_id":"NL_GM0575",
         "eurostat:nuts_2021_id":"GM0575",
         "hasc:id":"NL.ZH.NH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474223,
-    "wof:lastmodified":1684354026,
+    "wof:lastmodified":1695878795,
     "wof:name":"Noordwijkerhout",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/233/404474233.geojson
+++ b/data/404/474/233/404474233.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009846,
-    "geom:area_square_m":75301437.576944,
+    "geom:area_square_m":75301437.576943,
     "geom:bbox":"4.42369728591,51.7282562875,4.63163330954,51.8355495469",
     "geom:latitude":51.795036,
     "geom:longitude":4.5352,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.805538,
     "lbl:longitude":4.536764,
     "lbl:max_zoom":14.0,
@@ -148,13 +157,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0585",
         "hasc:id":"NL.ZH.BI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d614e322182421a60997b7980565663",
+    "wof:geomhash":"30fac048af8665a69ddaf930ba89fd61",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +176,7 @@
         }
     ],
     "wof:id":404474233,
-    "wof:lastmodified":1582362820,
+    "wof:lastmodified":1695878766,
     "wof:name":"Binnenmaas",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/235/404474235.geojson
+++ b/data/404/474/235/404474235.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010383,
-    "geom:area_square_m":79444016.428425,
+    "geom:area_square_m":79444016.428415,
     "geom:bbox":"4.22755732447,51.7097633631,4.41416758179,51.8240791605",
     "geom:latitude":51.77383,
     "geom:longitude":4.329611,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.781159,
     "lbl:longitude":4.341751,
     "lbl:max_zoom":15.0,
@@ -147,14 +156,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0588",
         "hasc:id":"NL.ZH.KO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"708b8967e0fbc2fcd4984b03e698bf33",
+    "wof:geomhash":"e50d1b9d59544b8aecf41391b712ad27",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +176,7 @@
         }
     ],
     "wof:id":404474235,
-    "wof:lastmodified":1582362814,
+    "wof:lastmodified":1695878764,
     "wof:name":"Korendijk",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/237/404474237.geojson
+++ b/data/404/474/237/404474237.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.027458,
     "geom:longitude":4.864242,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.029811,
     "lbl:longitude":4.873837,
     "lbl:max_zoom":15.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0589",
         "eg:gisco_id":"NL_GM0589",
         "eurostat:nuts_2021_id":"GM0589",
         "hasc:id":"NL.UT.OU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474237,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878795,
     "wof:name":"Oudewater",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/243/404474243.geojson
+++ b/data/404/474/243/404474243.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.868797,
     "geom:longitude":4.596107,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.869784,
     "lbl:longitude":4.592785,
     "lbl:max_zoom":14.0,
@@ -176,10 +185,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0597",
         "eg:gisco_id":"NL_GM0597",
         "eurostat:nuts_2021_id":"GM0597",
         "hasc:id":"NL.ZH.RK"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404474243,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878795,
     "wof:name":"Ridderkerk",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/259/404474259.geojson
+++ b/data/404/474/259/404474259.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007145,
-    "geom:area_square_m":54702585.078833,
+    "geom:area_square_m":54702585.078838,
     "geom:bbox":"4.3843524082,51.7005266662,4.53497484747,51.7883310445",
     "geom:latitude":51.743818,
     "geom:longitude":4.455153,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.750099,
     "lbl:longitude":4.45016,
     "lbl:max_zoom":15.0,
@@ -150,14 +159,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0611",
         "hasc:id":"NL.ZH.CR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"c22830256f4722290462df6683992735",
+    "wof:geomhash":"d7040fb816dda79c32f87fc84a2d3817",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474259,
-    "wof:lastmodified":1582362812,
+    "wof:lastmodified":1695878764,
     "wof:name":"Cromstrijen",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/263/404474263.geojson
+++ b/data/404/474/263/404474263.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.852041,
     "geom:longitude":4.43571,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.852315,
     "lbl:longitude":4.435805,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0613",
         "eg:gisco_id":"NL_GM0613",
         "eurostat:nuts_2021_id":"GM0613",
         "hasc:id":"NL.ZH.AW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474263,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878795,
     "wof:name":"Albrandswaard",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/267/404474267.geojson
+++ b/data/404/474/267/404474267.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.895084,
     "geom:longitude":4.091565,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.888722,
     "lbl:longitude":4.086028,
     "lbl:max_zoom":15.0,
@@ -160,10 +169,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0614",
         "eg:gisco_id":"NL_GM0614",
         "eurostat:nuts_2021_id":"GM0614",
         "hasc:id":"NL.ZH.WE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474267,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878795,
     "wof:name":"Westvoorne",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/271/404474271.geojson
+++ b/data/404/474/271/404474271.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005544,
-    "geom:area_square_m":42236537.027053,
+    "geom:area_square_m":42236537.027054,
     "geom:bbox":"5.04040220498,51.9333213949,5.18022665658,52.0030351286",
     "geom:latitude":51.969408,
     "geom:longitude":5.111424,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.971571,
     "lbl:longitude":5.112678,
     "lbl:max_zoom":15.0,
@@ -145,13 +154,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0620",
         "hasc:id":"NL.ZH.VI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"888038472f188a907ee50299ae5aa071",
+    "wof:geomhash":"617828410953ac9620bcc04da86c586e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -162,7 +173,7 @@
         }
     ],
     "wof:id":404474271,
-    "wof:lastmodified":1582362842,
+    "wof:lastmodified":1695878769,
     "wof:name":"Vianen",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/285/404474285.geojson
+++ b/data/404/474/285/404474285.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.106941,
     "geom:longitude":4.898887,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.106222,
     "lbl:longitude":4.897338,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0632",
         "eg:gisco_id":"NL_GM0632",
         "eurostat:nuts_2021_id":"GM0632",
         "hasc:id":"NL.UT.WR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474285,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878795,
     "wof:name":"Woerden",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/289/404474289.geojson
+++ b/data/404/474/289/404474289.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.114806,
     "geom:longitude":4.513834,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.114697,
     "lbl:longitude":4.513143,
     "lbl:max_zoom":15.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0638",
         "eg:gisco_id":"NL_GM0638",
         "eurostat:nuts_2021_id":"GM0638",
         "hasc:id":"NL.ZH.ZD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474289,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878796,
     "wof:name":"Zoeterwoude",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/291/404474291.geojson
+++ b/data/404/474/291/404474291.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.821843,
     "geom:longitude":4.605798,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.821177,
     "lbl:longitude":4.604669,
     "lbl:max_zoom":14.0,
@@ -128,10 +137,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0642",
         "eg:gisco_id":"NL_GM0642",
         "eurostat:nuts_2021_id":"GM0642",
         "hasc:id":"NL.ZH.ZW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -147,7 +158,7 @@
         }
     ],
     "wof:id":404474291,
-    "wof:lastmodified":1684354027,
+    "wof:lastmodified":1695878796,
     "wof:name":"Zwijndrecht",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/299/404474299.geojson
+++ b/data/404/474/299/404474299.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.445227,
     "geom:longitude":3.812963,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.43499,
     "lbl:longitude":3.824362,
     "lbl:max_zoom":14.0,
@@ -181,10 +190,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0654",
         "eg:gisco_id":"NL_GM0654",
         "eurostat:nuts_2021_id":"GM0654",
         "hasc:id":"NL.ZE.BO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -201,7 +212,7 @@
         }
     ],
     "wof:id":404474299,
-    "wof:lastmodified":1684354028,
+    "wof:lastmodified":1695878796,
     "wof:name":"Borsele",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/303/404474303.geojson
+++ b/data/404/474/303/404474303.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.515166,
     "geom:longitude":3.844875,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.516196,
     "lbl:longitude":3.821223,
     "lbl:max_zoom":14.0,
@@ -196,10 +205,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0664",
         "eg:gisco_id":"NL_GM0664",
         "eurostat:nuts_2021_id":"GM0664",
         "hasc:id":"NL.ZE.GO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -216,7 +227,7 @@
         }
     ],
     "wof:id":404474303,
-    "wof:lastmodified":1684354028,
+    "wof:lastmodified":1695878796,
     "wof:name":"Goes",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/305/404474305.geojson
+++ b/data/404/474/305/404474305.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.851629,
     "geom:longitude":5.496599,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.85986,
     "lbl:longitude":5.496798,
     "lbl:max_zoom":15.0,
@@ -149,10 +158,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0668",
         "eg:gisco_id":"NL_GM0668",
         "eurostat:nuts_2021_id":"GM0668",
         "hasc:id":"NL.GE.WM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474305,
-    "wof:lastmodified":1684354029,
+    "wof:lastmodified":1695878797,
     "wof:name":"West Maas en Waal",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/307/404474307.geojson
+++ b/data/404/474/307/404474307.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.321742,
     "geom:longitude":4.066263,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.306419,
     "lbl:longitude":4.044171,
     "lbl:max_zoom":14.0,
@@ -169,10 +178,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0677",
         "eg:gisco_id":"NL_GM0677",
         "eurostat:nuts_2021_id":"GM0677",
         "hasc:id":"NL.ZE.HU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474307,
-    "wof:lastmodified":1684354029,
+    "wof:lastmodified":1695878798,
     "wof:name":"Hulst",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/309/404474309.geojson
+++ b/data/404/474/309/404474309.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.484775,
     "geom:longitude":3.967578,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.484844,
     "lbl:longitude":3.973064,
     "lbl:max_zoom":15.0,
@@ -139,10 +148,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0678",
         "eg:gisco_id":"NL_GM0678",
         "eurostat:nuts_2021_id":"GM0678",
         "hasc:id":"NL.ZE.KA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -159,7 +170,7 @@
         }
     ],
     "wof:id":404474309,
-    "wof:lastmodified":1684354031,
+    "wof:lastmodified":1695878800,
     "wof:name":"Kapelle",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/313/404474313.geojson
+++ b/data/404/474/313/404474313.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.501764,
     "geom:longitude":3.647452,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.495197,
     "lbl:longitude":3.654227,
     "lbl:max_zoom":14.0,
@@ -274,10 +283,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0687",
         "eg:gisco_id":"NL_GM0687",
         "eurostat:nuts_2021_id":"GM0687",
         "hasc:id":"NL.ZE.MI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -294,7 +305,7 @@
         }
     ],
     "wof:id":404474313,
-    "wof:lastmodified":1684354032,
+    "wof:lastmodified":1695878800,
     "wof:name":"Middelburg",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/315/404474315.geojson
+++ b/data/404/474/315/404474315.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":51.872689,
     "geom:longitude":4.930039,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.865558,
     "lbl:longitude":4.915797,
     "lbl:max_zoom":15.0,
@@ -148,13 +157,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0689",
         "hasc:id":"NL.ZH.GI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"25a761e68509cf21384325402b60e09b",
+    "wof:geomhash":"82eff0074bc0316949d2e536895c0eef",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +176,7 @@
         }
     ],
     "wof:id":404474315,
-    "wof:lastmodified":1582362825,
+    "wof:lastmodified":1695878768,
     "wof:name":"Giessenlanden",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/323/404474323.geojson
+++ b/data/404/474/323/404474323.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.437044,
     "geom:longitude":4.137335,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.424129,
     "lbl:longitude":4.100794,
     "lbl:max_zoom":14.0,
@@ -136,10 +145,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0703",
         "eg:gisco_id":"NL_GM0703",
         "eurostat:nuts_2021_id":"GM0703",
         "hasc:id":"NL.ZE.RE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -156,7 +167,7 @@
         }
     ],
     "wof:id":404474323,
-    "wof:lastmodified":1684354032,
+    "wof:lastmodified":1695878801,
     "wof:name":"Reimerswaal",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/325/404474325.geojson
+++ b/data/404/474/325/404474325.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009998,
-    "geom:area_square_m":76226608.957026,
+    "geom:area_square_m":76226608.957031,
     "geom:bbox":"4.92630129213,51.8731191916,5.10144586573,51.9782155362",
     "geom:latitude":51.932366,
     "geom:longitude":5.013354,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.933715,
     "lbl:longitude":5.013272,
     "lbl:max_zoom":15.0,
@@ -145,13 +154,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0707",
         "hasc:id":"NL.ZH.ZE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff093a7432f5b0f6d3654331c698177a",
+    "wof:geomhash":"38e1e9d0213327d8b90203ae6aeeb533",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -162,7 +173,7 @@
         }
     ],
     "wof:id":404474325,
-    "wof:lastmodified":1582362827,
+    "wof:lastmodified":1695878768,
     "wof:name":"Zederik",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/329/404474329.geojson
+++ b/data/404/474/329/404474329.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.28791,
     "geom:longitude":3.845922,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.273325,
     "lbl:longitude":3.858141,
     "lbl:max_zoom":14.0,
@@ -214,10 +223,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0715",
         "eg:gisco_id":"NL_GM0715",
         "eurostat:nuts_2021_id":"GM0715",
         "hasc:id":"NL.ZE.TE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -234,7 +245,7 @@
         }
     ],
     "wof:id":404474329,
-    "wof:lastmodified":1684354032,
+    "wof:lastmodified":1695878802,
     "wof:name":"Terneuzen",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/331/404474331.geojson
+++ b/data/404/474/331/404474331.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.572904,
     "geom:longitude":4.132684,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.562772,
     "lbl:longitude":4.14494,
     "lbl:max_zoom":14.0,
@@ -175,10 +184,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0716",
         "eg:gisco_id":"NL_GM0716",
         "eurostat:nuts_2021_id":"GM0716",
         "hasc:id":"NL.ZE.TH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404474331,
-    "wof:lastmodified":1684354033,
+    "wof:lastmodified":1695878802,
     "wof:name":"Tholen",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/333/404474333.geojson
+++ b/data/404/474/333/404474333.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.537833,
     "geom:longitude":3.556991,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.536618,
     "lbl:longitude":3.541967,
     "lbl:max_zoom":14.0,
@@ -172,10 +181,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0717",
         "eg:gisco_id":"NL_GM0717",
         "eurostat:nuts_2021_id":"GM0717",
         "hasc:id":"NL.ZE.VE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474333,
-    "wof:lastmodified":1684354036,
+    "wof:lastmodified":1695878805,
     "wof:name":"Veere",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/335/404474335.geojson
+++ b/data/404/474/335/404474335.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.460212,
     "geom:longitude":3.619333,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.459208,
     "lbl:longitude":3.618506,
     "lbl:max_zoom":14.0,
@@ -223,10 +232,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0718",
         "eg:gisco_id":"NL_GM0718",
         "eurostat:nuts_2021_id":"GM0718",
         "hasc:id":"NL.ZE.VL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -243,7 +254,7 @@
         }
     ],
     "wof:id":404474335,
-    "wof:lastmodified":1684354037,
+    "wof:lastmodified":1695878806,
     "wof:name":"Vlissingen",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/339/404474339.geojson
+++ b/data/404/474/339/404474339.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":51.847587,
     "geom:longitude":5.089311,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.852594,
     "lbl:longitude":5.087722,
     "lbl:max_zoom":15.0,
@@ -139,13 +148,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0733",
         "hasc:id":"NL.GE.LW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a3b788155358783a11df3ca00a76a32",
+    "wof:geomhash":"32a265a5d8dff20a0f1c9de486401770",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +167,7 @@
         }
     ],
     "wof:id":404474339,
-    "wof:lastmodified":1582362804,
+    "wof:lastmodified":1695878763,
     "wof:name":"Lingewaal",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/341/404474341.geojson
+++ b/data/404/474/341/404474341.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.226344,
     "geom:longitude":4.917328,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.207003,
     "lbl:longitude":4.896312,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0736",
         "eg:gisco_id":"NL_GM0736",
         "eurostat:nuts_2021_id":"GM0736",
         "hasc:id":"NL.UT.DV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474341,
-    "wof:lastmodified":1684354037,
+    "wof:lastmodified":1695878807,
     "wof:name":"De Ronde Venen",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/343/404474343.geojson
+++ b/data/404/474/343/404474343.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.199872,
     "geom:longitude":5.962665,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.181079,
     "lbl:longitude":5.972307,
     "lbl:max_zoom":14.0,
@@ -172,10 +181,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0737",
         "eg:gisco_id":"NL_GM0737",
         "eurostat:nuts_2021_id":"GM0737",
         "hasc:id":"NL.FR.TY"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -191,7 +202,7 @@
         }
     ],
     "wof:id":404474343,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878807,
     "wof:name":"Tytsjerksteradiel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/474/345/404474345.geojson
+++ b/data/404/474/345/404474345.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006921,
-    "geom:area_square_m":52984141.530073,
+    "geom:area_square_m":52984141.530072,
     "geom:bbox":"4.98863692158,51.7108133747,5.1427138174,51.7876475857",
     "geom:latitude":51.745818,
     "geom:longitude":5.065145,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.739601,
     "lbl:longitude":5.051406,
     "lbl:max_zoom":15.0,
@@ -169,13 +178,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0738",
         "hasc:id":"NL.NB.AA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e9d8dd8ff02d6a2810ffd4e5280632f",
+    "wof:geomhash":"503df25688fa0de709bb5cfcf95c4916",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474345,
-    "wof:lastmodified":1582362853,
+    "wof:lastmodified":1695878769,
     "wof:name":"Aalburg",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/347/404474347.geojson
+++ b/data/404/474/347/404474347.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.386415,
     "geom:longitude":5.779206,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.375802,
     "lbl:longitude":5.7851,
     "lbl:max_zoom":15.0,
@@ -104,10 +113,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0743",
         "eg:gisco_id":"NL_GM0743",
         "eurostat:nuts_2021_id":"GM0743",
         "hasc:id":"NL.NB.AS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -123,7 +134,7 @@
         }
     ],
     "wof:id":404474347,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878807,
     "wof:name":"Asten",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/349/404474349.geojson
+++ b/data/404/474/349/404474349.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.439012,
     "geom:longitude":4.893151,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.446912,
     "lbl:longitude":4.873987,
     "lbl:max_zoom":15.0,
@@ -200,10 +209,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0744",
         "eg:gisco_id":"NL_GM0744",
         "eurostat:nuts_2021_id":"GM0744",
         "hasc:id":"NL.NB.BN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -219,7 +230,7 @@
         }
     ],
     "wof:id":404474349,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Baarle-Nassau",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/351/404474351.geojson
+++ b/data/404/474/351/404474351.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.503472,
     "geom:longitude":4.288292,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.50679,
     "lbl:longitude":4.274585,
     "lbl:max_zoom":14.0,
@@ -224,10 +233,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0748",
         "eg:gisco_id":"NL_GM0748",
         "eurostat:nuts_2021_id":"GM0748",
         "hasc:id":"NL.NB.BZ"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -243,7 +254,7 @@
         }
     ],
     "wof:id":404474351,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Bergen op Zoom",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/353/404474353.geojson
+++ b/data/404/474/353/404474353.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.513657,
     "geom:longitude":5.396465,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.515754,
     "lbl:longitude":5.397453,
     "lbl:max_zoom":14.0,
@@ -125,10 +134,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0753",
         "eg:gisco_id":"NL_GM0753",
         "eurostat:nuts_2021_id":"GM0753",
         "hasc:id":"NL.NB.BS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101754563
     ],
@@ -147,7 +158,7 @@
         }
     ],
     "wof:id":404474353,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Best",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/357/404474357.geojson
+++ b/data/404/474/357/404474357.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.606673,
     "geom:longitude":5.693725,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.605586,
     "lbl:longitude":5.693842,
     "lbl:max_zoom":15.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0755",
         "eg:gisco_id":"NL_GM0755",
         "eurostat:nuts_2021_id":"GM0755",
         "hasc:id":"NL.NB.BO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474357,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Boekel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/359/404474359.geojson
+++ b/data/404/474/359/404474359.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.621547,
     "geom:longitude":5.948999,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.602332,
     "lbl:longitude":5.987684,
     "lbl:max_zoom":14.0,
@@ -170,10 +179,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0756",
         "eg:gisco_id":"NL_GM0756",
         "eurostat:nuts_2021_id":"GM0756",
         "hasc:id":"NL.NB.BM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474359,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Boxmeer",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/361/404474361.geojson
+++ b/data/404/474/361/404474361.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.578256,
     "geom:longitude":5.326575,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.580894,
     "lbl:longitude":5.318717,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0757",
         "eg:gisco_id":"NL_GM0757",
         "eurostat:nuts_2021_id":"GM0757",
         "hasc:id":"NL.NB.BT"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474361,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Boxtel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/363/404474363.geojson
+++ b/data/404/474/363/404474363.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.585132,
     "geom:longitude":4.76143,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.577729,
     "lbl:longitude":4.761313,
     "lbl:max_zoom":14.0,
@@ -296,10 +305,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0758",
         "eg:gisco_id":"NL_GM0758",
         "eurostat:nuts_2021_id":"GM0758",
         "hasc:id":"NL.NB.BR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -315,7 +326,7 @@
         }
     ],
     "wof:id":404474363,
-    "wof:lastmodified":1684354038,
+    "wof:lastmodified":1695878808,
     "wof:name":"Breda",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/365/404474365.geojson
+++ b/data/404/474/365/404474365.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.436238,
     "geom:longitude":5.826932,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.450264,
     "lbl:longitude":5.81976,
     "lbl:max_zoom":14.0,
@@ -98,10 +107,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0762",
         "eg:gisco_id":"NL_GM0762",
         "eurostat:nuts_2021_id":"GM0762",
         "hasc:id":"NL.NB.DE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -117,7 +128,7 @@
         }
     ],
     "wof:id":404474365,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878808,
     "wof:name":"Deurne",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/367/404474367.geojson
+++ b/data/404/474/367/404474367.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.0706,
     "geom:longitude":6.972969,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.072874,
     "lbl:longitude":6.97197,
     "lbl:max_zoom":15.0,
@@ -170,10 +179,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0765",
         "eg:gisco_id":"NL_GM0765",
         "eurostat:nuts_2021_id":"GM0765",
         "hasc:id":"NL.GR.PE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474367,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878808,
     "wof:name":"Pekela",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/474/369/404474369.geojson
+++ b/data/404/474/369/404474369.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.635888,
     "geom:longitude":4.955446,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.635534,
     "lbl:longitude":4.946227,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0766",
         "eg:gisco_id":"NL_GM0766",
         "eurostat:nuts_2021_id":"GM0766",
         "hasc:id":"NL.NB.DO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474369,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878808,
     "wof:name":"Dongen",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/371/404474371.geojson
+++ b/data/404/474/371/404474371.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.396522,
     "geom:longitude":5.314615,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.359829,
     "lbl:longitude":5.309492,
     "lbl:max_zoom":15.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0770",
         "eg:gisco_id":"NL_GM0770",
         "eurostat:nuts_2021_id":"GM0770",
         "hasc:id":"NL.NB.EE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474371,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Eersel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/377/404474377.geojson
+++ b/data/404/474/377/404474377.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.578328,
     "geom:longitude":4.644959,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.580398,
     "lbl:longitude":4.640782,
     "lbl:max_zoom":14.0,
@@ -176,10 +185,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0777",
         "eg:gisco_id":"NL_GM0777",
         "eurostat:nuts_2021_id":"GM0777",
         "hasc:id":"NL.NB.EL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101839355
     ],
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474377,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Etten-Leur",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/379/404474379.geojson
+++ b/data/404/474/379/404474379.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.697144,
     "geom:longitude":4.881581,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.697032,
     "lbl:longitude":4.881326,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0779",
         "eg:gisco_id":"NL_GM0779",
         "eurostat:nuts_2021_id":"GM0779",
         "hasc:id":"NL.NB.GE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474379,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Geertruidenberg",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/381/404474381.geojson
+++ b/data/404/474/381/404474381.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.559596,
     "geom:longitude":4.918582,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.557277,
     "lbl:longitude":4.913399,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0784",
         "eg:gisco_id":"NL_GM0784",
         "eurostat:nuts_2021_id":"GM0784",
         "hasc:id":"NL.NB.GR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474381,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Gilze en Rijen",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/383/404474383.geojson
+++ b/data/404/474/383/404474383.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.511751,
     "geom:longitude":5.031697,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.508273,
     "lbl:longitude":5.018858,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0785",
         "eg:gisco_id":"NL_GM0785",
         "eurostat:nuts_2021_id":"GM0785",
         "hasc:id":"NL.NB.GO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474383,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Goirle",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/385/404474385.geojson
+++ b/data/404/474/385/404474385.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.743574,
     "geom:longitude":5.74301,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.740139,
     "lbl:longitude":5.744307,
     "lbl:max_zoom":15.0,
@@ -257,10 +266,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0786",
         "eg:gisco_id":"NL_GM0786",
         "eurostat:nuts_2021_id":"GM0786",
         "hasc:id":"NL.NB.GV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -276,7 +287,7 @@
         }
     ],
     "wof:id":404474385,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Grave",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/387/404474387.geojson
+++ b/data/404/474/387/404474387.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.626054,
     "geom:longitude":5.218095,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.626457,
     "lbl:longitude":5.21235,
     "lbl:max_zoom":15.0,
@@ -95,10 +104,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0788",
         "eg:gisco_id":"NL_GM0788",
         "eurostat:nuts_2021_id":"GM0788",
         "hasc:id":"NL.NB.HR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -114,7 +125,7 @@
         }
     ],
     "wof:id":404474387,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Haaren",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/389/404474389.geojson
+++ b/data/404/474/389/404474389.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.47615,
     "geom:longitude":5.656963,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.481771,
     "lbl:longitude":5.655383,
     "lbl:max_zoom":14.0,
@@ -224,10 +233,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0794",
         "eg:gisco_id":"NL_GM0794",
         "eurostat:nuts_2021_id":"GM0794",
         "hasc:id":"NL.NB.HM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -243,7 +254,7 @@
         }
     ],
     "wof:id":404474389,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"Helmond",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/393/404474393.geojson
+++ b/data/404/474/393/404474393.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.716721,
     "geom:longitude":5.35179,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.709383,
     "lbl:longitude":5.322958,
     "lbl:max_zoom":14.0,
@@ -283,9 +292,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0796",
         "eg:gisco_id":"NL_GM0796",
         "eurostat:nuts_2021_id":"GM0796"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -301,7 +312,7 @@
         }
     ],
     "wof:id":404474393,
-    "wof:lastmodified":1684354039,
+    "wof:lastmodified":1695878809,
     "wof:name":"'s-Hertogenbosch",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/395/404474395.geojson
+++ b/data/404/474/395/404474395.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.696771,
     "geom:longitude":5.160201,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.705569,
     "lbl:longitude":5.167216,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0797",
         "eg:gisco_id":"NL_GM0797",
         "eurostat:nuts_2021_id":"GM0797",
         "hasc:id":"NL.NB.HS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474395,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878809,
     "wof:name":"Heusden",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/397/404474397.geojson
+++ b/data/404/474/397/404474397.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.479531,
     "geom:longitude":5.145455,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.476977,
     "lbl:longitude":5.138711,
     "lbl:max_zoom":15.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0798",
         "eg:gisco_id":"NL_GM0798",
         "eurostat:nuts_2021_id":"GM0798",
         "hasc:id":"NL.NB.HI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404474397,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Hilvarenbeek",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/401/404474401.geojson
+++ b/data/404/474/401/404474401.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.640572,
     "geom:longitude":5.04754,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.636637,
     "lbl:longitude":5.030818,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0809",
         "eg:gisco_id":"NL_GM0809",
         "eurostat:nuts_2021_id":"GM0809",
         "hasc:id":"NL.NB.LZ"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474401,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Loon op Zand",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/403/404474403.geojson
+++ b/data/404/474/403/404474403.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.685845,
     "geom:longitude":5.768041,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.681935,
     "lbl:longitude":5.768101,
     "lbl:max_zoom":15.0,
@@ -149,10 +158,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0815",
         "eg:gisco_id":"NL_GM0815",
         "eurostat:nuts_2021_id":"GM0815",
         "hasc:id":"NL.NB.MS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474403,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Mill en Sint Hubert",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/405/404474405.geojson
+++ b/data/404/474/405/404474405.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.47861,
     "geom:longitude":5.549461,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.478846,
     "lbl:longitude":5.549577,
     "lbl:max_zoom":14.0,
@@ -80,10 +89,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0820",
         "eg:gisco_id":"NL_GM0820",
         "eurostat:nuts_2021_id":"GM0820",
         "hasc:id":"NL.NB.NG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -99,7 +110,7 @@
         }
     ],
     "wof:id":404474405,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Nuenen, Gerwen en Nederwetten",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/407/404474407.geojson
+++ b/data/404/474/407/404474407.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.492625,
     "geom:longitude":5.289802,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.500975,
     "lbl:longitude":5.296784,
     "lbl:max_zoom":15.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0823",
         "eg:gisco_id":"NL_GM0823",
         "eurostat:nuts_2021_id":"GM0823",
         "hasc:id":"NL.NB.OR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474407,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Oirschot",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/411/404474411.geojson
+++ b/data/404/474/411/404474411.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.552107,
     "geom:longitude":5.197528,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.548342,
     "lbl:longitude":5.196087,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0824",
         "eg:gisco_id":"NL_GM0824",
         "eurostat:nuts_2021_id":"GM0824",
         "hasc:id":"NL.NB.OW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474411,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Oisterwijk",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/413/404474413.geojson
+++ b/data/404/474/413/404474413.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.637783,
     "geom:longitude":4.864062,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.641454,
     "lbl:longitude":4.865456,
     "lbl:max_zoom":14.0,
@@ -176,10 +185,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0826",
         "eg:gisco_id":"NL_GM0826",
         "eurostat:nuts_2021_id":"GM0826",
         "hasc:id":"NL.NB.OO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404474413,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Oosterhout",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/415/404474415.geojson
+++ b/data/404/474/415/404474415.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.781549,
     "geom:longitude":5.526405,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.786707,
     "lbl:longitude":5.577937,
     "lbl:max_zoom":14.0,
@@ -206,10 +215,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0828",
         "eg:gisco_id":"NL_GM0828",
         "eurostat:nuts_2021_id":"GM0828",
         "hasc:id":"NL.NB.OS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -225,7 +236,7 @@
         }
     ],
     "wof:id":404474415,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Oss",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/417/404474417.geojson
+++ b/data/404/474/417/404474417.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.522678,
     "geom:longitude":4.558573,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.522254,
     "lbl:longitude":4.550997,
     "lbl:max_zoom":14.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0840",
         "eg:gisco_id":"NL_GM0840",
         "eurostat:nuts_2021_id":"GM0840",
         "hasc:id":"NL.NB.RU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404474417,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Rucphen",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/419/404474419.geojson
+++ b/data/404/474/419/404474419.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":51.622101,
     "geom:longitude":5.436507,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.622134,
     "lbl:longitude":5.436232,
     "lbl:max_zoom":14.0,
@@ -139,13 +148,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0844",
         "hasc:id":"NL.NB.SC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0f72098c1cec858efefb124e6a733a47",
+    "wof:geomhash":"4f0002a0b5cfa3b2a49251f20eff70b3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +167,7 @@
         }
     ],
     "wof:id":404474419,
-    "wof:lastmodified":1582362838,
+    "wof:lastmodified":1695878768,
     "wof:name":"Schijndel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/421/404474421.geojson
+++ b/data/404/474/421/404474421.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.657075,
     "geom:longitude":5.378143,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.672777,
     "lbl:longitude":5.392026,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0845",
         "eg:gisco_id":"NL_GM0845",
         "eurostat:nuts_2021_id":"GM0845",
         "hasc:id":"NL.NB.SM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474421,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Sint-Michielsgestel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/423/404474423.geojson
+++ b/data/404/474/423/404474423.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008418,
-    "geom:area_square_m":64705490.217562,
+    "geom:area_square_m":64705490.21756,
     "geom:bbox":"5.38052876269,51.52129624,5.5506934502,51.6054236386",
     "geom:latitude":51.563699,
     "geom:longitude":5.468882,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.569768,
     "lbl:longitude":5.462191,
     "lbl:max_zoom":15.0,
@@ -139,13 +148,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0846",
         "hasc:id":"NL.NB.SO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"69386c4872dd539b23ee4b34383413a2",
+    "wof:geomhash":"597306c354bb5556502666d3dd4a9138",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +167,7 @@
         }
     ],
     "wof:id":404474423,
-    "wof:lastmodified":1582362811,
+    "wof:lastmodified":1695878764,
     "wof:name":"Sint-Oedenrode",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/425/404474425.geojson
+++ b/data/404/474/425/404474425.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.378752,
     "geom:longitude":5.691404,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.364921,
     "lbl:longitude":5.695642,
     "lbl:max_zoom":15.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0847",
         "eg:gisco_id":"NL_GM0847",
         "eurostat:nuts_2021_id":"GM0847",
         "hasc:id":"NL.NB.SR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404474425,
-    "wof:lastmodified":1684354040,
+    "wof:lastmodified":1695878810,
     "wof:name":"Someren",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/429/404474429.geojson
+++ b/data/404/474/429/404474429.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.516375,
     "geom:longitude":5.482462,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.518518,
     "lbl:longitude":5.472185,
     "lbl:max_zoom":15.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0848",
         "eg:gisco_id":"NL_GM0848",
         "eurostat:nuts_2021_id":"GM0848",
         "hasc:id":"NL.NB.SB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404474429,
-    "wof:lastmodified":1684354041,
+    "wof:lastmodified":1695878811,
     "wof:name":"Son en Breugel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/431/404474431.geojson
+++ b/data/404/474/431/404474431.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.59736,
     "geom:longitude":4.324925,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.598326,
     "lbl:longitude":4.324659,
     "lbl:max_zoom":14.0,
@@ -157,10 +166,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0851",
         "eg:gisco_id":"NL_GM0851",
         "eurostat:nuts_2021_id":"GM0851",
         "hasc:id":"NL.NB.ST"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474431,
-    "wof:lastmodified":1684354041,
+    "wof:lastmodified":1695878811,
     "wof:name":"Steenbergen",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/433/404474433.geojson
+++ b/data/404/474/433/404474433.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007382,
-    "geom:area_square_m":55624770.979871,
+    "geom:area_square_m":55624770.97987,
     "geom:bbox":"4.94686554607,52.4151292726,5.13936547634,52.4947327665",
     "geom:latitude":52.452282,
     "geom:longitude":5.01463,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.454471,
     "lbl:longitude":5.004918,
     "lbl:max_zoom":15.0,
@@ -168,14 +177,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0852",
         "hasc:id":"NL.NH.WA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"da926dc4cd574c370047dfa60bfd3d59",
+    "wof:geomhash":"e2492f56d4a7521e86bf5da468199aa3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474433,
-    "wof:lastmodified":1582362846,
+    "wof:lastmodified":1695878769,
     "wof:name":"Waterland",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/435/404474435.geojson
+++ b/data/404/474/435/404474435.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.57963,
     "geom:longitude":5.06853,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.573371,
     "lbl:longitude":5.070415,
     "lbl:max_zoom":13.0,
@@ -287,10 +296,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0855",
         "eg:gisco_id":"NL_GM0855",
         "eurostat:nuts_2021_id":"GM0855",
         "hasc:id":"NL.NB.TI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -306,7 +317,7 @@
         }
     ],
     "wof:id":404474435,
-    "wof:lastmodified":1684354041,
+    "wof:lastmodified":1695878811,
     "wof:name":"Tilburg",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/437/404474437.geojson
+++ b/data/404/474/437/404474437.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.655487,
     "geom:longitude":5.651829,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.660172,
     "lbl:longitude":5.62693,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0856",
         "eg:gisco_id":"NL_GM0856",
         "eurostat:nuts_2021_id":"GM0856",
         "hasc:id":"NL.NB.UD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474437,
-    "wof:lastmodified":1684354041,
+    "wof:lastmodified":1695878811,
     "wof:name":"Uden",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/439/404474439.geojson
+++ b/data/404/474/439/404474439.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.323767,
     "geom:longitude":5.449247,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.310448,
     "lbl:longitude":5.455957,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0858",
         "eg:gisco_id":"NL_GM0858",
         "eurostat:nuts_2021_id":"GM0858",
         "hasc:id":"NL.NB.VA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474439,
-    "wof:lastmodified":1684354041,
+    "wof:lastmodified":1695878812,
     "wof:name":"Valkenswaard",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/441/404474441.geojson
+++ b/data/404/474/441/404474441.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010239,
-    "geom:area_square_m":78641310.019623,
+    "geom:area_square_m":78641310.019622,
     "geom:bbox":"5.48517771981,51.553237967,5.65655581397,51.6514342507",
     "geom:latitude":51.599921,
     "geom:longitude":5.574139,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.604175,
     "lbl:longitude":5.565559,
     "lbl:max_zoom":14.0,
@@ -73,13 +82,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0860",
         "hasc:id":"NL.NB.VG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"820d6481a764203f6cab0449cbdc8b8b",
+    "wof:geomhash":"36619e0bee7f3fa2c68a29be65b05300",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -90,7 +101,7 @@
         }
     ],
     "wof:id":404474441,
-    "wof:lastmodified":1582362808,
+    "wof:lastmodified":1695878763,
     "wof:name":"Veghel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/443/404474443.geojson
+++ b/data/404/474/443/404474443.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.411895,
     "geom:longitude":5.383252,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.407343,
     "lbl:longitude":5.39657,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0861",
         "eg:gisco_id":"NL_GM0861",
         "eurostat:nuts_2021_id":"GM0861",
         "hasc:id":"NL.NB.VH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474443,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Veldhoven",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/447/404474447.geojson
+++ b/data/404/474/447/404474447.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.655394,
     "geom:longitude":5.268695,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.652613,
     "lbl:longitude":5.273523,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0865",
         "eg:gisco_id":"NL_GM0865",
         "eurostat:nuts_2021_id":"GM0865",
         "hasc:id":"NL.NB.VU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474447,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Vught",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/449/404474449.geojson
+++ b/data/404/474/449/404474449.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.387291,
     "geom:longitude":5.46487,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.387325,
     "lbl:longitude":5.464562,
     "lbl:max_zoom":15.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0866",
         "eg:gisco_id":"NL_GM0866",
         "eurostat:nuts_2021_id":"GM0866",
         "hasc:id":"NL.NB.WR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404474449,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Waalre",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/451/404474451.geojson
+++ b/data/404/474/451/404474451.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.692314,
     "geom:longitude":5.01182,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.692257,
     "lbl:longitude":5.011782,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0867",
         "eg:gisco_id":"NL_GM0867",
         "eurostat:nuts_2021_id":"GM0867",
         "hasc:id":"NL.NB.WW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474451,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Waalwijk",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/453/404474453.geojson
+++ b/data/404/474/453/404474453.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015855,
-    "geom:area_square_m":121328170.548225,
+    "geom:area_square_m":121328170.548224,
     "geom:bbox":"4.67630422372,51.7126118636,5.00039036015,51.8285291907",
     "geom:latitude":51.767093,
     "geom:longitude":4.873125,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.769364,
     "lbl:longitude":4.889119,
     "lbl:max_zoom":14.0,
@@ -145,13 +154,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0870",
         "hasc:id":"NL.NB.WE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e5604cce82c9e8d49d3efc096f124355",
+    "wof:geomhash":"c36e2697861c133c657a9e30fcacc6a8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -162,7 +173,7 @@
         }
     ],
     "wof:id":404474453,
-    "wof:lastmodified":1582362820,
+    "wof:lastmodified":1695878767,
     "wof:name":"Werkendam",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/455/404474455.geojson
+++ b/data/404/474/455/404474455.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.4083,
     "geom:longitude":4.342256,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.418796,
     "lbl:longitude":4.340462,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0873",
         "eg:gisco_id":"NL_GM0873",
         "eurostat:nuts_2021_id":"GM0873",
         "hasc:id":"NL.NB.WD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474455,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Woensdrecht",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/457/404474457.geojson
+++ b/data/404/474/457/404474457.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006735,
-    "geom:area_square_m":51519475.215172,
+    "geom:area_square_m":51519475.215171,
     "geom:bbox":"4.9316692403,51.7509573032,5.08662103055,51.8236543637",
     "geom:latitude":51.782573,
     "geom:longitude":4.994771,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.786462,
     "lbl:longitude":4.988624,
     "lbl:max_zoom":15.0,
@@ -148,13 +157,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0874",
         "hasc:id":"NL.NB.WO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c0aa91f15f4e0182ecc1afb20c889b2",
+    "wof:geomhash":"14fb43e861777a0cfc236911b55f5489",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -165,7 +176,7 @@
         }
     ],
     "wof:id":404474457,
-    "wof:lastmodified":1582362847,
+    "wof:lastmodified":1695878769,
     "wof:name":"Woudrichem",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/459/404474459.geojson
+++ b/data/404/474/459/404474459.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.479807,
     "geom:longitude":4.642659,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.474812,
     "lbl:longitude":4.640795,
     "lbl:max_zoom":14.0,
@@ -191,10 +200,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0879",
         "eg:gisco_id":"NL_GM0879",
         "eurostat:nuts_2021_id":"GM0879",
         "hasc:id":"NL.NB.ZU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -210,7 +221,7 @@
         }
     ],
     "wof:id":404474459,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Zundert",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/461/404474461.geojson
+++ b/data/404/474/461/404474461.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.502,
     "geom:longitude":4.855124,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.49746,
     "lbl:longitude":4.856467,
     "lbl:max_zoom":15.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0880",
         "eg:gisco_id":"NL_GM0880",
         "eurostat:nuts_2021_id":"GM0880",
         "hasc:id":"NL.NH.WO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474461,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Wormerland",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/465/404474465.geojson
+++ b/data/404/474/465/404474465.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":50.969931,
     "geom:longitude":5.966471,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.969231,
     "lbl:longitude":5.948228,
     "lbl:max_zoom":15.0,
@@ -136,13 +145,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0881",
         "hasc:id":"NL.LI.ON"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f20ce6f781a610f7919e6c948b831e0a",
+    "wof:geomhash":"a8737a92acd960b1e9be38bff40a5249",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -153,7 +164,7 @@
         }
     ],
     "wof:id":404474465,
-    "wof:lastmodified":1582362820,
+    "wof:lastmodified":1695878767,
     "wof:name":"Onderbanken",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/467/404474467.geojson
+++ b/data/404/474/467/404474467.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.906431,
     "geom:longitude":6.03299,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.907584,
     "lbl:longitude":6.024601,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0882",
         "eg:gisco_id":"NL_GM0882",
         "eurostat:nuts_2021_id":"GM0882",
         "hasc:id":"NL.LI.LA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474467,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Landgraaf",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/471/404474471.geojson
+++ b/data/404/474/471/404474471.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.930877,
     "geom:longitude":5.809108,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.934512,
     "lbl:longitude":5.816821,
     "lbl:max_zoom":15.0,
@@ -95,10 +104,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0888",
         "eg:gisco_id":"NL_GM0888",
         "eurostat:nuts_2021_id":"GM0888",
         "hasc:id":"NL.LI.BK"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -114,7 +125,7 @@
         }
     ],
     "wof:id":404474471,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Beek",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/473/404474473.geojson
+++ b/data/404/474/473/404474473.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.269166,
     "geom:longitude":6.068963,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.268493,
     "lbl:longitude":6.068708,
     "lbl:max_zoom":15.0,
@@ -170,10 +179,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0889",
         "eg:gisco_id":"NL_GM0889",
         "eurostat:nuts_2021_id":"GM0889",
         "hasc:id":"NL.LI.BS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474473,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Beesel",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/475/404474475.geojson
+++ b/data/404/474/475/404474475.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.591942,
     "geom:longitude":6.089304,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.617378,
     "lbl:longitude":6.058856,
     "lbl:max_zoom":15.0,
@@ -67,9 +76,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0893",
         "eg:gisco_id":"NL_GM0893",
         "eurostat:nuts_2021_id":"GM0893"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -85,7 +96,7 @@
         }
     ],
     "wof:id":404474475,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878812,
     "wof:name":"Bergen (L.)",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/483/404474483.geojson
+++ b/data/404/474/483/404474483.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.699286,
     "geom:longitude":5.987098,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.700683,
     "lbl:longitude":5.992423,
     "lbl:max_zoom":15.0,
@@ -176,10 +185,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0907",
         "eg:gisco_id":"NL_GM0907",
         "eurostat:nuts_2021_id":"GM0907",
         "hasc:id":"NL.LI.GE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404474483,
-    "wof:lastmodified":1684354042,
+    "wof:lastmodified":1695878813,
     "wof:name":"Gennep",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/485/404474485.geojson
+++ b/data/404/474/485/404474485.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.893336,
     "geom:longitude":5.969414,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.895562,
     "lbl:longitude":5.96996,
     "lbl:max_zoom":14.0,
@@ -221,10 +230,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0917",
         "eg:gisco_id":"NL_GM0917",
         "eurostat:nuts_2021_id":"GM0917",
         "hasc:id":"NL.LI.HR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -240,7 +251,7 @@
         }
     ],
     "wof:id":404474485,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Heerlen",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/489/404474489.geojson
+++ b/data/404/474/489/404474489.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.871829,
     "geom:longitude":6.050979,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.876098,
     "lbl:longitude":6.058211,
     "lbl:max_zoom":14.0,
@@ -197,10 +206,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0928",
         "eg:gisco_id":"NL_GM0928",
         "eurostat:nuts_2021_id":"GM0928",
         "hasc:id":"NL.LI.KR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:coterminous":[
         101839255
     ],
@@ -219,7 +230,7 @@
         }
     ],
     "wof:id":404474489,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Kerkrade",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/501/404474501.geojson
+++ b/data/404/474/501/404474501.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.901349,
     "geom:longitude":5.756415,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.916498,
     "lbl:longitude":5.744276,
     "lbl:max_zoom":15.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0938",
         "eg:gisco_id":"NL_GM0938",
         "eurostat:nuts_2021_id":"GM0938",
         "hasc:id":"NL.LI.MS"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474501,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Meerssen",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/505/404474505.geojson
+++ b/data/404/474/505/404474505.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.74737,
     "geom:longitude":5.899658,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.745102,
     "lbl:longitude":5.899001,
     "lbl:max_zoom":15.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0944",
         "eg:gisco_id":"NL_GM0944",
         "eurostat:nuts_2021_id":"GM0944",
         "hasc:id":"NL.LI.MM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474505,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Mook en Middelaar",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/507/404474507.geojson
+++ b/data/404/474/507/404474507.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.294358,
     "geom:longitude":5.773316,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.293197,
     "lbl:longitude":5.774965,
     "lbl:max_zoom":15.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0946",
         "eg:gisco_id":"NL_GM0946",
         "eurostat:nuts_2021_id":"GM0946",
         "hasc:id":"NL.LI.NE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474507,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Nederweert",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/509/404474509.geojson
+++ b/data/404/474/509/404474509.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004233,
-    "geom:area_square_m":33009567.627914,
+    "geom:area_square_m":33009567.627915,
     "geom:bbox":"5.79655697145,50.880648244,5.9237207685,50.9349914832",
     "geom:latitude":50.905422,
     "geom:longitude":5.85962,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.904109,
     "lbl:longitude":5.859707,
     "lbl:max_zoom":15.0,
@@ -142,13 +151,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0951",
         "hasc:id":"NL.LI.NU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3afeddb2761d27f48dc27009c0b5b0ee",
+    "wof:geomhash":"b77cb830ae2d2af3ae45ef6d4551b4c4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -159,7 +170,7 @@
         }
     ],
     "wof:id":404474509,
-    "wof:lastmodified":1582362833,
+    "wof:lastmodified":1695878768,
     "wof:name":"Nuth",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/511/404474511.geojson
+++ b/data/404/474/511/404474511.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.201196,
     "geom:longitude":6.011493,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.201159,
     "lbl:longitude":6.017325,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0957",
         "eg:gisco_id":"NL_GM0957",
         "eurostat:nuts_2021_id":"GM0957",
         "hasc:id":"NL.LI.RM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474511,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Roermond",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/513/404474513.geojson
+++ b/data/404/474/513/404474513.geojson
@@ -15,6 +15,15 @@
     "geom:latitude":50.950449,
     "geom:longitude":5.887633,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.953156,
     "lbl:longitude":5.896767,
     "lbl:max_zoom":15.0,
@@ -139,13 +148,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0962",
         "hasc:id":"NL.LI.SC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8367fe87d4fa42cddea7912f56697ae0",
+    "wof:geomhash":"9f2c3d3d62c12e6b00477f667ef70aab",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -156,7 +167,7 @@
         }
     ],
     "wof:id":404474513,
-    "wof:lastmodified":1582362853,
+    "wof:lastmodified":1695878769,
     "wof:name":"Schinnen",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/519/404474519.geojson
+++ b/data/404/474/519/404474519.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.828806,
     "geom:longitude":5.986639,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.829454,
     "lbl:longitude":5.987199,
     "lbl:max_zoom":15.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0965",
         "eg:gisco_id":"NL_GM0965",
         "eurostat:nuts_2021_id":"GM0965",
         "hasc:id":"NL.LI.SI"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474519,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Simpelveld",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/521/404474521.geojson
+++ b/data/404/474/521/404474521.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.969001,
     "geom:longitude":5.763669,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.972736,
     "lbl:longitude":5.766063,
     "lbl:max_zoom":14.0,
@@ -168,12 +177,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0971",
         "eg:gisco_id":"NL_GM0971",
         "eurostat:nuts_2021_id":"GM0971",
         "gp:id":12684458,
         "hasc:id":"NL.LI.ST",
         "qs_pg:id":1084122
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -190,7 +201,7 @@
         }
     ],
     "wof:id":404474521,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Stein",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/523/404474523.geojson
+++ b/data/404/474/523/404474523.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.774335,
     "geom:longitude":5.975845,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.777986,
     "lbl:longitude":5.974893,
     "lbl:max_zoom":15.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0981",
         "eg:gisco_id":"NL_GM0981",
         "eurostat:nuts_2021_id":"GM0981",
         "hasc:id":"NL.LI.VA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474523,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878813,
     "wof:name":"Vaals",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/525/404474525.geojson
+++ b/data/404/474/525/404474525.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.391008,
     "geom:longitude":6.159152,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.361215,
     "lbl:longitude":6.152037,
     "lbl:max_zoom":14.0,
@@ -239,10 +248,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0983",
         "eg:gisco_id":"NL_GM0983",
         "eurostat:nuts_2021_id":"GM0983",
         "hasc:id":"NL.LI.VL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -258,7 +269,7 @@
         }
     ],
     "wof:id":404474525,
-    "wof:lastmodified":1684354043,
+    "wof:lastmodified":1695878814,
     "wof:name":"Venlo",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/527/404474527.geojson
+++ b/data/404/474/527/404474527.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.515363,
     "geom:longitude":5.9629,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.509288,
     "lbl:longitude":5.947672,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0984",
         "eg:gisco_id":"NL_GM0984",
         "eurostat:nuts_2021_id":"GM0984",
         "hasc:id":"NL.LI.VR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474527,
-    "wof:lastmodified":1684354044,
+    "wof:lastmodified":1695878814,
     "wof:name":"Venray",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/529/404474529.geojson
+++ b/data/404/474/529/404474529.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.869367,
     "geom:longitude":5.916493,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.873186,
     "lbl:longitude":5.917407,
     "lbl:max_zoom":15.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0986",
         "eg:gisco_id":"NL_GM0986",
         "eurostat:nuts_2021_id":"GM0986",
         "hasc:id":"NL.LI.VO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474529,
-    "wof:lastmodified":1684354044,
+    "wof:lastmodified":1695878814,
     "wof:name":"Voerendaal",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/531/404474531.geojson
+++ b/data/404/474/531/404474531.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.23361,
     "geom:longitude":5.691695,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.233559,
     "lbl:longitude":5.699726,
     "lbl:max_zoom":14.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0988",
         "eg:gisco_id":"NL_GM0988",
         "eurostat:nuts_2021_id":"GM0988",
         "hasc:id":"NL.LI.WE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474531,
-    "wof:lastmodified":1684354044,
+    "wof:lastmodified":1695878814,
     "wof:name":"Weert",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/537/404474537.geojson
+++ b/data/404/474/537/404474537.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.860711,
     "geom:longitude":5.823866,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.862614,
     "lbl:longitude":5.819371,
     "lbl:max_zoom":15.0,
@@ -86,10 +95,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM0994",
         "eg:gisco_id":"NL_GM0994",
         "eurostat:nuts_2021_id":"GM0994",
         "hasc:id":"NL.LI.VG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -105,7 +116,7 @@
         }
     ],
     "wof:id":404474537,
-    "wof:lastmodified":1684354044,
+    "wof:lastmodified":1695878814,
     "wof:name":"Valkenburg aan de Geul",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/541/404474541.geojson
+++ b/data/404/474/541/404474541.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.444866,
     "geom:longitude":6.041694,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.457228,
     "lbl:longitude":6.053081,
     "lbl:max_zoom":14.0,
@@ -86,10 +95,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1507",
         "eg:gisco_id":"NL_GM1507",
         "eurostat:nuts_2021_id":"GM1507",
         "hasc:id":"NL.LI.HM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -105,7 +116,7 @@
         }
     ],
     "wof:id":404474541,
-    "wof:lastmodified":1684354044,
+    "wof:lastmodified":1695878814,
     "wof:name":"Horst aan de Maas",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/543/404474543.geojson
+++ b/data/404/474/543/404474543.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.907839,
     "geom:longitude":6.409534,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.918336,
     "lbl:longitude":6.427896,
     "lbl:max_zoom":14.0,
@@ -145,9 +154,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1509",
         "eg:gisco_id":"NL_GM1509",
         "eurostat:nuts_2021_id":"GM1509"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -163,7 +174,7 @@
         }
     ],
     "wof:id":404474543,
-    "wof:lastmodified":1684354044,
+    "wof:lastmodified":1695878814,
     "wof:name":"Oude IJsselstreek",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/545/404474545.geojson
+++ b/data/404/474/545/404474545.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.214002,
     "geom:longitude":4.511898,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.214375,
     "lbl:longitude":4.511539,
     "lbl:max_zoom":14.0,
@@ -142,9 +151,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1525",
         "eg:gisco_id":"NL_GM1525",
         "eurostat:nuts_2021_id":"GM1525"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -160,7 +171,7 @@
         }
     ],
     "wof:id":404474545,
-    "wof:lastmodified":1684354045,
+    "wof:lastmodified":1695878815,
     "wof:name":"Teylingen",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/547/404474547.geojson
+++ b/data/404/474/547/404474547.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.034706,
     "geom:longitude":5.388289,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.041971,
     "lbl:longitude":5.376488,
     "lbl:max_zoom":14.0,
@@ -151,9 +160,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1581",
         "eg:gisco_id":"NL_GM1581",
         "eurostat:nuts_2021_id":"GM1581"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -169,7 +180,7 @@
         }
     ],
     "wof:id":404474547,
-    "wof:lastmodified":1684354045,
+    "wof:lastmodified":1695878815,
     "wof:name":"Utrechtse Heuvelrug",
     "wof:parent_id":85687039,
     "wof:placetype":"localadmin",

--- a/data/404/474/549/404474549.geojson
+++ b/data/404/474/549/404474549.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.009687,
     "geom:longitude":6.575589,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.005363,
     "lbl:longitude":6.61214,
     "lbl:max_zoom":14.0,
@@ -130,9 +139,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1586",
         "eg:gisco_id":"NL_GM1586",
         "eurostat:nuts_2021_id":"GM1586"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -148,7 +159,7 @@
         }
     ],
     "wof:id":404474549,
-    "wof:lastmodified":1684354045,
+    "wof:lastmodified":1695878815,
     "wof:name":"Oost Gelre",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/551/404474551.geojson
+++ b/data/404/474/551/404474551.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.644692,
     "geom:longitude":4.94815,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.643198,
     "lbl:longitude":4.940879,
     "lbl:max_zoom":14.0,
@@ -162,9 +171,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1598",
         "eg:gisco_id":"NL_GM1598",
         "eurostat:nuts_2021_id":"GM1598"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -181,7 +192,7 @@
         }
     ],
     "wof:id":404474551,
-    "wof:lastmodified":1684354045,
+    "wof:lastmodified":1695878815,
     "wof:name":"Koggenland",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/555/404474555.geojson
+++ b/data/404/474/555/404474555.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.004023,
     "geom:longitude":4.506135,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.000056,
     "lbl:longitude":4.512968,
     "lbl:max_zoom":14.0,
@@ -148,9 +157,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1621",
         "eg:gisco_id":"NL_GM1621",
         "eurostat:nuts_2021_id":"GM1621"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -166,7 +177,7 @@
         }
     ],
     "wof:id":404474555,
-    "wof:lastmodified":1684354045,
+    "wof:lastmodified":1695878815,
     "wof:name":"Lansingerland",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/557/404474557.geojson
+++ b/data/404/474/557/404474557.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.239455,
     "geom:longitude":5.884875,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.261013,
     "lbl:longitude":5.904777,
     "lbl:max_zoom":14.0,
@@ -145,9 +154,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1640",
         "eg:gisco_id":"NL_GM1640",
         "eurostat:nuts_2021_id":"GM1640"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -163,7 +174,7 @@
         }
     ],
     "wof:id":404474557,
-    "wof:lastmodified":1684354045,
+    "wof:lastmodified":1695878815,
     "wof:name":"Leudal",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/559/404474559.geojson
+++ b/data/404/474/559/404474559.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.161582,
     "geom:longitude":5.882405,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.163086,
     "lbl:longitude":5.881577,
     "lbl:max_zoom":14.0,
@@ -145,9 +154,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1641",
         "eg:gisco_id":"NL_GM1641",
         "eurostat:nuts_2021_id":"GM1641"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -163,7 +174,7 @@
         }
     ],
     "wof:id":404474559,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Maasgouw",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/561/404474561.geojson
+++ b/data/404/474/561/404474561.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025784,
-    "geom:area_square_m":189999675.769461,
+    "geom:area_square_m":189999675.769454,
     "geom:bbox":"6.39081625949,53.3422311675,6.88462379271,53.555014503",
     "geom:latitude":53.420611,
     "geom:longitude":6.674379,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.41359,
     "lbl:longitude":6.684724,
     "lbl:max_zoom":15.0,
@@ -165,14 +174,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1651",
         "hasc:id":"NL.GR.EE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
         "mz"
     ],
-    "wof:geomhash":"e9f66ff635839ae99aba3a44ef05eb46",
+    "wof:geomhash":"395ce0f1a604ff2770bb2200fe5bccfc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474561,
-    "wof:lastmodified":1582362803,
+    "wof:lastmodified":1695878762,
     "wof:name":"Eemsmond",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/474/563/404474563.geojson
+++ b/data/404/474/563/404474563.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.540755,
     "geom:longitude":5.754279,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.540512,
     "lbl:longitude":5.754367,
     "lbl:max_zoom":14.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1652",
         "eg:gisco_id":"NL_GM1652",
         "eurostat:nuts_2021_id":"GM1652",
         "hasc:id":"NL.NB.GB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474563,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Gemert-Bakel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/565/404474565.geojson
+++ b/data/404/474/565/404474565.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.590537,
     "geom:longitude":4.523118,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.591467,
     "lbl:longitude":4.549156,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1655",
         "eg:gisco_id":"NL_GM1655",
         "eurostat:nuts_2021_id":"GM1655",
         "hasc:id":"NL.NB.HB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474565,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Halderberge",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/567/404474567.geojson
+++ b/data/404/474/567/404474567.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.360874,
     "geom:longitude":5.567263,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.365007,
     "lbl:longitude":5.568426,
     "lbl:max_zoom":15.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1658",
         "eg:gisco_id":"NL_GM1658",
         "eurostat:nuts_2021_id":"GM1658",
         "hasc:id":"NL.NB.HL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474567,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Heeze-Leende",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/569/404474569.geojson
+++ b/data/404/474/569/404474569.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.530923,
     "geom:longitude":5.611767,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.533074,
     "lbl:longitude":5.597768,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1659",
         "eg:gisco_id":"NL_GM1659",
         "eurostat:nuts_2021_id":"GM1659",
         "hasc:id":"NL.NB.LB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474569,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Laarbeek",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/575/404474575.geojson
+++ b/data/404/474/575/404474575.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023329,
-    "geom:area_square_m":172089684.294043,
+    "geom:area_square_m":172089684.294041,
     "geom:bbox":"6.17866672652,53.3138361304,6.54774653892,53.4329658393",
     "geom:latitude":53.374821,
     "geom:longitude":6.362349,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.368333,
     "lbl:longitude":6.378026,
     "lbl:max_zoom":15.0,
@@ -162,14 +171,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1663",
         "hasc:id":"NL.GR.DM"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"26a670ead05f1975d2a2b4225565bb53",
+    "wof:geomhash":"c9f41b6d2a5b632fb490aa28a7e6db04",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474575,
-    "wof:lastmodified":1582362823,
+    "wof:lastmodified":1695878767,
     "wof:name":"De Marne",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/404/474/579/404474579.geojson
+++ b/data/404/474/579/404474579.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.378273,
     "geom:longitude":5.14774,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.386168,
     "lbl:longitude":5.146581,
     "lbl:max_zoom":15.0,
@@ -152,10 +161,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1667",
         "eg:gisco_id":"NL_GM1667",
         "eurostat:nuts_2021_id":"GM1667",
         "hasc:id":"NL.NB.RD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -171,7 +182,7 @@
         }
     ],
     "wof:id":404474579,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Reusel-De Mierden",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/581/404474581.geojson
+++ b/data/404/474/581/404474581.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.145687,
     "geom:longitude":6.041118,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.135735,
     "lbl:longitude":6.039342,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1669",
         "eg:gisco_id":"NL_GM1669",
         "eurostat:nuts_2021_id":"GM1669",
         "hasc:id":"NL.LI.RD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474581,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Roerdalen",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/587/404474587.geojson
+++ b/data/404/474/587/404474587.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.513198,
     "geom:longitude":4.424518,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.507037,
     "lbl:longitude":4.422919,
     "lbl:max_zoom":14.0,
@@ -197,10 +206,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1674",
         "eg:gisco_id":"NL_GM1674",
         "eurostat:nuts_2021_id":"GM1674",
         "hasc:id":"NL.NB.RO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -216,7 +227,7 @@
         }
     ],
     "wof:id":404474587,
-    "wof:lastmodified":1684354046,
+    "wof:lastmodified":1695878816,
     "wof:name":"Roosendaal",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/591/404474591.geojson
+++ b/data/404/474/591/404474591.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.687372,
     "geom:longitude":3.900453,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.684341,
     "lbl:longitude":3.937258,
     "lbl:max_zoom":14.0,
@@ -187,10 +196,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1676",
         "eg:gisco_id":"NL_GM1676",
         "eurostat:nuts_2021_id":"GM1676",
         "hasc:id":"NL.ZE.SD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -207,7 +218,7 @@
         }
     ],
     "wof:id":404474591,
-    "wof:lastmodified":1684354047,
+    "wof:lastmodified":1695878817,
     "wof:name":"Schouwen-Duiveland",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/593/404474593.geojson
+++ b/data/404/474/593/404474593.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.993024,
     "geom:longitude":6.72733,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.017231,
     "lbl:longitude":6.740073,
     "lbl:max_zoom":14.0,
@@ -185,10 +194,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1680",
         "eg:gisco_id":"NL_GM1680",
         "eurostat:nuts_2021_id":"GM1680",
         "hasc:id":"NL.DR.AH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -204,7 +215,7 @@
         }
     ],
     "wof:id":404474593,
-    "wof:lastmodified":1684354049,
+    "wof:lastmodified":1695878819,
     "wof:name":"Aa en Hunze",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/595/404474595.geojson
+++ b/data/404/474/595/404474595.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.905896,
     "geom:longitude":6.871991,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.902175,
     "lbl:longitude":6.871928,
     "lbl:max_zoom":14.0,
@@ -170,10 +179,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1681",
         "eg:gisco_id":"NL_GM1681",
         "eurostat:nuts_2021_id":"GM1681",
         "hasc:id":"NL.DR.BO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474595,
-    "wof:lastmodified":1684354049,
+    "wof:lastmodified":1695878819,
     "wof:name":"Borger-Odoorn",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/597/404474597.geojson
+++ b/data/404/474/597/404474597.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.718305,
     "geom:longitude":5.851363,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.720655,
     "lbl:longitude":5.850298,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1684",
         "eg:gisco_id":"NL_GM1684",
         "eurostat:nuts_2021_id":"GM1684",
         "hasc:id":"NL.NB.CU"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474597,
-    "wof:lastmodified":1684354049,
+    "wof:lastmodified":1695878819,
     "wof:name":"Cuijk",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/599/404474599.geojson
+++ b/data/404/474/599/404474599.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.716658,
     "geom:longitude":5.658943,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.716119,
     "lbl:longitude":5.659035,
     "lbl:max_zoom":15.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1685",
         "eg:gisco_id":"NL_GM1685",
         "eurostat:nuts_2021_id":"GM1685",
         "hasc:id":"NL.NB.LN"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474599,
-    "wof:lastmodified":1684354049,
+    "wof:lastmodified":1695878819,
     "wof:name":"Landerd",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/601/404474601.geojson
+++ b/data/404/474/601/404474601.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.701694,
     "geom:longitude":6.373419,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.718353,
     "lbl:longitude":6.349597,
     "lbl:max_zoom":14.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1690",
         "eg:gisco_id":"NL_GM1690",
         "eurostat:nuts_2021_id":"GM1690",
         "hasc:id":"NL.DR.DW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474601,
-    "wof:lastmodified":1684354049,
+    "wof:lastmodified":1695878820,
     "wof:name":"De Wolden",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/603/404474603.geojson
+++ b/data/404/474/603/404474603.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.574038,
     "geom:longitude":3.772339,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.575646,
     "lbl:longitude":3.794005,
     "lbl:max_zoom":15.0,
@@ -178,10 +187,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1695",
         "eg:gisco_id":"NL_GM1695",
         "eurostat:nuts_2021_id":"GM1695",
         "hasc:id":"NL.ZE.NB"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474603,
-    "wof:lastmodified":1684354050,
+    "wof:lastmodified":1695878820,
     "wof:name":"Noord-Beveland",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/605/404474605.geojson
+++ b/data/404/474/605/404474605.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.226196,
     "geom:longitude":5.08484,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.213186,
     "lbl:longitude":5.085912,
     "lbl:max_zoom":14.0,
@@ -163,9 +172,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1696",
         "eg:gisco_id":"NL_GM1696",
         "eurostat:nuts_2021_id":"GM1696"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -181,7 +192,7 @@
         }
     ],
     "wof:id":404474605,
-    "wof:lastmodified":1684354051,
+    "wof:lastmodified":1695878821,
     "wof:name":"Wijdemeren",
     "wof:parent_id":85687053,
     "wof:placetype":"localadmin",

--- a/data/404/474/609/404474609.geojson
+++ b/data/404/474/609/404474609.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.095683,
     "geom:longitude":6.440337,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.081167,
     "lbl:longitude":6.42892,
     "lbl:max_zoom":14.0,
@@ -176,10 +185,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1699",
         "eg:gisco_id":"NL_GM1699",
         "eurostat:nuts_2021_id":"GM1699",
         "hasc:id":"NL.DR.NO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -195,7 +206,7 @@
         }
     ],
     "wof:id":404474609,
-    "wof:lastmodified":1684354051,
+    "wof:lastmodified":1695878821,
     "wof:name":"Noordenveld",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/611/404474611.geojson
+++ b/data/404/474/611/404474611.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.447886,
     "geom:longitude":6.598059,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.432538,
     "lbl:longitude":6.631847,
     "lbl:max_zoom":14.0,
@@ -148,9 +157,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1700",
         "eg:gisco_id":"NL_GM1700",
         "eurostat:nuts_2021_id":"GM1700"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -166,7 +177,7 @@
         }
     ],
     "wof:id":404474611,
-    "wof:lastmodified":1684354051,
+    "wof:lastmodified":1695878822,
     "wof:name":"Twenterand",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/613/404474613.geojson
+++ b/data/404/474/613/404474613.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.838204,
     "geom:longitude":6.295535,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.852281,
     "lbl:longitude":6.277958,
     "lbl:max_zoom":15.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1701",
         "eg:gisco_id":"NL_GM1701",
         "eurostat:nuts_2021_id":"GM1701",
         "hasc:id":"NL.DR.WE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474613,
-    "wof:lastmodified":1684354051,
+    "wof:lastmodified":1695878822,
     "wof:name":"Westerveld",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/615/404474615.geojson
+++ b/data/404/474/615/404474615.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.617317,
     "geom:longitude":5.841993,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.616179,
     "lbl:longitude":5.832307,
     "lbl:max_zoom":15.0,
@@ -149,10 +158,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1702",
         "eg:gisco_id":"NL_GM1702",
         "eurostat:nuts_2021_id":"GM1702",
         "hasc:id":"NL.NB.SA"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474615,
-    "wof:lastmodified":1684354052,
+    "wof:lastmodified":1695878822,
     "wof:name":"Sint Anthonis",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/617/404474617.geojson
+++ b/data/404/474/617/404474617.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.901537,
     "geom:longitude":5.942223,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.911781,
     "lbl:longitude":5.935474,
     "lbl:max_zoom":14.0,
@@ -145,9 +154,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1705",
         "eg:gisco_id":"NL_GM1705",
         "eurostat:nuts_2021_id":"GM1705"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -163,7 +174,7 @@
         }
     ],
     "wof:id":404474617,
-    "wof:lastmodified":1684354052,
+    "wof:lastmodified":1695878822,
     "wof:name":"Lingewaard",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/619/404474619.geojson
+++ b/data/404/474/619/404474619.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.286294,
     "geom:longitude":5.596195,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.286584,
     "lbl:longitude":5.58873,
     "lbl:max_zoom":14.0,
@@ -161,10 +170,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1706",
         "eg:gisco_id":"NL_GM1706",
         "eurostat:nuts_2021_id":"GM1706",
         "hasc:id":"NL.NB.CR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -180,7 +191,7 @@
         }
     ],
     "wof:id":404474619,
-    "wof:lastmodified":1684354052,
+    "wof:lastmodified":1695878822,
     "wof:name":"Cranendonck",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/621/404474621.geojson
+++ b/data/404/474/621/404474621.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.755581,
     "geom:longitude":6.029977,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.734428,
     "lbl:longitude":6.043726,
     "lbl:max_zoom":14.0,
@@ -156,9 +165,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1708",
         "eg:gisco_id":"NL_GM1708",
         "eurostat:nuts_2021_id":"GM1708"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -175,7 +186,7 @@
         }
     ],
     "wof:id":404474621,
-    "wof:lastmodified":1684354052,
+    "wof:lastmodified":1695878822,
     "wof:name":"Steenwijkerland",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/623/404474623.geojson
+++ b/data/404/474/623/404474623.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.658802,
     "geom:longitude":4.541923,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.651244,
     "lbl:longitude":4.531039,
     "lbl:max_zoom":14.0,
@@ -166,10 +175,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1709",
         "eg:gisco_id":"NL_GM1709",
         "eurostat:nuts_2021_id":"GM1709",
         "hasc:id":"NL.NB.MO"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474623,
-    "wof:lastmodified":1684354052,
+    "wof:lastmodified":1695878823,
     "wof:name":"Moerdijk",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/627/404474627.geojson
+++ b/data/404/474/627/404474627.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.08504,
     "geom:longitude":5.908211,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.092999,
     "lbl:longitude":5.886465,
     "lbl:max_zoom":14.0,
@@ -154,9 +163,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1711",
         "eg:gisco_id":"NL_GM1711",
         "eurostat:nuts_2021_id":"GM1711"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -172,7 +183,7 @@
         }
     ],
     "wof:id":404474627,
-    "wof:lastmodified":1684354053,
+    "wof:lastmodified":1695878823,
     "wof:name":"Echt-Susteren",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/629/404474629.geojson
+++ b/data/404/474/629/404474629.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.328523,
     "geom:longitude":3.515262,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.347637,
     "lbl:longitude":3.518567,
     "lbl:max_zoom":14.0,
@@ -186,9 +195,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1714",
         "eg:gisco_id":"NL_GM1714",
         "eurostat:nuts_2021_id":"GM1714"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
@@ -205,7 +216,7 @@
         }
     ],
     "wof:id":404474629,
-    "wof:lastmodified":1684354053,
+    "wof:lastmodified":1695878823,
     "wof:name":"Sluis",
     "wof:parent_id":85687037,
     "wof:placetype":"localadmin",

--- a/data/404/474/631/404474631.geojson
+++ b/data/404/474/631/404474631.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.700162,
     "geom:longitude":4.75877,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.69477,
     "lbl:longitude":4.750106,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1719",
         "eg:gisco_id":"NL_GM1719",
         "eurostat:nuts_2021_id":"GM1719",
         "hasc:id":"NL.NB.DR"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474631,
-    "wof:lastmodified":1684354053,
+    "wof:lastmodified":1695878824,
     "wof:name":"Drimmelen",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/633/404474633.geojson
+++ b/data/404/474/633/404474633.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.684694,
     "geom:longitude":5.520681,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.673192,
     "lbl:longitude":5.519421,
     "lbl:max_zoom":14.0,
@@ -167,10 +176,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1721",
         "eg:gisco_id":"NL_GM1721",
         "eurostat:nuts_2021_id":"GM1721",
         "hasc:id":"NL.NB.BH"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -186,7 +197,7 @@
         }
     ],
     "wof:id":404474633,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878824,
     "wof:name":"Bernheze",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/635/404474635.geojson
+++ b/data/404/474/635/404474635.geojson
@@ -11,11 +11,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013309,
-    "geom:area_square_m":98297441.290757,
+    "geom:area_square_m":98297441.290766,
     "geom:bbox":"5.71890917631,53.2749348513,5.93662930755,53.3766382845",
     "geom:latitude":53.322456,
     "geom:longitude":5.827451,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.321815,
     "lbl:longitude":5.825105,
     "lbl:max_zoom":15.0,
@@ -169,14 +178,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1722",
         "hasc:id":"NL.FR.FE"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "mz",
         "quattroshapes"
     ],
-    "wof:geomhash":"dd706158354841da945b1c04102d1015",
+    "wof:geomhash":"291adabf706eed389623518bdfc80b26",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +198,7 @@
         }
     ],
     "wof:id":404474635,
-    "wof:lastmodified":1582362819,
+    "wof:lastmodified":1695878766,
     "wof:name":"Ferwerderadiel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/474/637/404474637.geojson
+++ b/data/404/474/637/404474637.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.501372,
     "geom:longitude":4.887325,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.507304,
     "lbl:longitude":4.863253,
     "lbl:max_zoom":15.0,
@@ -173,10 +182,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1723",
         "eg:gisco_id":"NL_GM1723",
         "eurostat:nuts_2021_id":"GM1723",
         "hasc:id":"NL.NB.AC"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -192,7 +203,7 @@
         }
     ],
     "wof:id":404474637,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878824,
     "wof:name":"Alphen-Chaam",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/639/404474639.geojson
+++ b/data/404/474/639/404474639.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.310149,
     "geom:longitude":5.340042,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.304735,
     "lbl:longitude":5.359042,
     "lbl:max_zoom":15.0,
@@ -149,10 +158,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1724",
         "eg:gisco_id":"NL_GM1724",
         "eurostat:nuts_2021_id":"GM1724",
         "hasc:id":"NL.NB.BG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474639,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878824,
     "wof:name":"Bergeijk",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/641/404474641.geojson
+++ b/data/404/474/641/404474641.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.372307,
     "geom:longitude":5.238734,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.373811,
     "lbl:longitude":5.237785,
     "lbl:max_zoom":15.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1728",
         "eg:gisco_id":"NL_GM1728",
         "eurostat:nuts_2021_id":"GM1728",
         "hasc:id":"NL.NB.BL"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474641,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878825,
     "wof:name":"Bladel",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/645/404474645.geojson
+++ b/data/404/474/645/404474645.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":50.80235,
     "geom:longitude":5.900152,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.805745,
     "lbl:longitude":5.901291,
     "lbl:max_zoom":15.0,
@@ -164,10 +173,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1729",
         "eg:gisco_id":"NL_GM1729",
         "eurostat:nuts_2021_id":"GM1729",
         "hasc:id":"NL.LI.GW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474645,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878825,
     "wof:name":"Gulpen-Wittem",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/647/404474647.geojson
+++ b/data/404/474/647/404474647.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":53.097111,
     "geom:longitude":6.604353,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.101965,
     "lbl:longitude":6.58963,
     "lbl:max_zoom":14.0,
@@ -179,10 +188,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1730",
         "eg:gisco_id":"NL_GM1730",
         "eurostat:nuts_2021_id":"GM1730",
         "hasc:id":"NL.DR.TY"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -198,7 +209,7 @@
         }
     ],
     "wof:id":404474647,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878825,
     "wof:name":"Tynaarlo",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/649/404474649.geojson
+++ b/data/404/474/649/404474649.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.867405,
     "geom:longitude":6.542666,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.848408,
     "lbl:longitude":6.555104,
     "lbl:max_zoom":14.0,
@@ -170,10 +179,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1731",
         "eg:gisco_id":"NL_GM1731",
         "eurostat:nuts_2021_id":"GM1731",
         "hasc:id":"NL.DR.MD"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -189,7 +200,7 @@
         }
     ],
     "wof:id":404474649,
-    "wof:lastmodified":1684354054,
+    "wof:lastmodified":1695878825,
     "wof:name":"Midden-Drenthe",
     "wof:parent_id":85687051,
     "wof:placetype":"localadmin",

--- a/data/404/474/651/404474651.geojson
+++ b/data/404/474/651/404474651.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.924302,
     "geom:longitude":5.778318,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.919022,
     "lbl:longitude":5.77807,
     "lbl:max_zoom":14.0,
@@ -158,10 +167,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1734",
         "eg:gisco_id":"NL_GM1734",
         "eurostat:nuts_2021_id":"GM1734",
         "hasc:id":"NL.GE.OV"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -177,7 +188,7 @@
         }
     ],
     "wof:id":404474651,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878825,
     "wof:name":"Overbetuwe",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/653/404474653.geojson
+++ b/data/404/474/653/404474653.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.236434,
     "geom:longitude":6.589991,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.226268,
     "lbl:longitude":6.590051,
     "lbl:max_zoom":14.0,
@@ -155,10 +164,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1735",
         "eg:gisco_id":"NL_GM1735",
         "eurostat:nuts_2021_id":"GM1735",
         "hasc:id":"NL.OV.HT"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -174,7 +185,7 @@
         }
     ],
     "wof:id":404474653,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878826,
     "wof:name":"Hof van Twente",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/655/404474655.geojson
+++ b/data/404/474/655/404474655.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.91587,
     "geom:longitude":5.586876,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.923602,
     "lbl:longitude":5.594253,
     "lbl:max_zoom":14.0,
@@ -145,9 +154,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1740",
         "eg:gisco_id":"NL_GM1740",
         "eurostat:nuts_2021_id":"GM1740"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -163,7 +174,7 @@
         }
     ],
     "wof:id":404474655,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878826,
     "wof:name":"Neder-Betuwe",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/657/404474657.geojson
+++ b/data/404/474/657/404474657.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.291425,
     "geom:longitude":6.43398,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.288293,
     "lbl:longitude":6.431818,
     "lbl:max_zoom":14.0,
@@ -151,9 +160,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1742",
         "eg:gisco_id":"NL_GM1742",
         "eurostat:nuts_2021_id":"GM1742"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -169,7 +180,7 @@
         }
     ],
     "wof:id":404474657,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878826,
     "wof:name":"Rijssen-Holten",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/659/404474659.geojson
+++ b/data/404/474/659/404474659.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.431274,
     "geom:longitude":5.587572,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.436582,
     "lbl:longitude":5.588308,
     "lbl:max_zoom":14.0,
@@ -151,9 +160,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1771",
         "eg:gisco_id":"NL_GM1771",
         "eurostat:nuts_2021_id":"GM1771"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -169,7 +180,7 @@
         }
     ],
     "wof:id":404474659,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878826,
     "wof:name":"Geldrop-Mierlo",
     "wof:parent_id":85687035,
     "wof:placetype":"localadmin",

--- a/data/404/474/663/404474663.geojson
+++ b/data/404/474/663/404474663.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.36681,
     "geom:longitude":6.153362,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.348083,
     "lbl:longitude":6.15154,
     "lbl:max_zoom":15.0,
@@ -148,9 +157,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1773",
         "eg:gisco_id":"NL_GM1773",
         "eurostat:nuts_2021_id":"GM1773"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -166,7 +177,7 @@
         }
     ],
     "wof:id":404474663,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878826,
     "wof:name":"Olst-Wijhe",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/665/404474665.geojson
+++ b/data/404/474/665/404474665.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.373027,
     "geom:longitude":6.914216,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.382075,
     "lbl:longitude":6.914158,
     "lbl:max_zoom":14.0,
@@ -157,9 +166,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1774",
         "eg:gisco_id":"NL_GM1774",
         "eurostat:nuts_2021_id":"GM1774"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -175,7 +186,7 @@
         }
     ],
     "wof:id":404474665,
-    "wof:lastmodified":1684354055,
+    "wof:lastmodified":1695878826,
     "wof:name":"Dinkelland",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/667/404474667.geojson
+++ b/data/404/474/667/404474667.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.99802,
     "geom:longitude":4.21632,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.991462,
     "lbl:longitude":4.218539,
     "lbl:max_zoom":14.0,
@@ -102,9 +111,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1783",
         "eg:gisco_id":"NL_GM1783",
         "eurostat:nuts_2021_id":"GM1783"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -121,7 +132,7 @@
         }
     ],
     "wof:id":404474667,
-    "wof:lastmodified":1684354056,
+    "wof:lastmodified":1695878826,
     "wof:name":"Westland",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/669/404474669.geojson
+++ b/data/404/474/669/404474669.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.96476,
     "geom:longitude":4.306153,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.960959,
     "lbl:longitude":4.307578,
     "lbl:max_zoom":15.0,
@@ -148,9 +157,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1842",
         "eg:gisco_id":"NL_GM1842",
         "eurostat:nuts_2021_id":"GM1842"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -166,7 +177,7 @@
         }
     ],
     "wof:id":404474669,
-    "wof:lastmodified":1684354056,
+    "wof:lastmodified":1695878827,
     "wof:name":"Midden-Delfland",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/671/404474671.geojson
+++ b/data/404/474/671/404474671.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.100878,
     "geom:longitude":6.570828,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.111691,
     "lbl:longitude":6.558421,
     "lbl:max_zoom":14.0,
@@ -154,9 +163,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1859",
         "eg:gisco_id":"NL_GM1859",
         "eurostat:nuts_2021_id":"GM1859"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -172,7 +183,7 @@
         }
     ],
     "wof:id":404474671,
-    "wof:lastmodified":1684354056,
+    "wof:lastmodified":1695878827,
     "wof:name":"Berkelland",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/673/404474673.geojson
+++ b/data/404/474/673/404474673.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.04524,
     "geom:longitude":6.302945,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.064628,
     "lbl:longitude":6.324572,
     "lbl:max_zoom":14.0,
@@ -160,9 +169,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1876",
         "eg:gisco_id":"NL_GM1876",
         "eurostat:nuts_2021_id":"GM1876"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -178,7 +189,7 @@
         }
     ],
     "wof:id":404474673,
-    "wof:lastmodified":1684354056,
+    "wof:lastmodified":1695878827,
     "wof:name":"Bronckhorst",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/675/404474675.geojson
+++ b/data/404/474/675/404474675.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.004872,
     "geom:longitude":5.828193,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":50.999024,
     "lbl:longitude":5.828172,
     "lbl:max_zoom":14.0,
@@ -194,10 +203,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1883",
         "eg:gisco_id":"NL_GM1883",
         "eurostat:nuts_2021_id":"GM1883",
         "hasc:id":"NL.LI.SG"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -213,7 +224,7 @@
         }
     ],
     "wof:id":404474675,
-    "wof:lastmodified":1684354056,
+    "wof:lastmodified":1695878827,
     "wof:name":"Sittard-Geleen",
     "wof:parent_id":85687033,
     "wof:placetype":"localadmin",

--- a/data/404/474/677/404474677.geojson
+++ b/data/404/474/677/404474677.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.19258,
     "geom:longitude":4.629212,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.188195,
     "lbl:longitude":4.628997,
     "lbl:max_zoom":14.0,
@@ -136,9 +145,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1884",
         "eg:gisco_id":"NL_GM1884",
         "eurostat:nuts_2021_id":"GM1884"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -154,7 +165,7 @@
         }
     ],
     "wof:id":404474677,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878828,
     "wof:name":"Kaag en Braassem",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/681/404474681.geojson
+++ b/data/404/474/681/404474681.geojson
@@ -28,6 +28,15 @@
     "geom:latitude":53.280049,
     "geom:longitude":5.984528,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.269706,
     "lbl:longitude":5.984417,
     "lbl:max_zoom":15.0,
@@ -165,9 +174,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1891",
         "eg:gisco_id":"NL_GM1891",
         "eurostat:nuts_2021_id":"GM1891"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474681,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878828,
     "wof:name":"Dantumadiel",
     "wof:parent_id":85687055,
     "wof:placetype":"localadmin",

--- a/data/404/474/683/404474683.geojson
+++ b/data/404/474/683/404474683.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.602426,
     "geom:longitude":6.064358,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.608899,
     "lbl:longitude":6.058047,
     "lbl:max_zoom":14.0,
@@ -163,10 +172,12 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1896",
         "eg:gisco_id":"NL_GM1896",
         "eurostat:nuts_2021_id":"GM1896",
         "hasc:id":"NL.OV.ZW"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -183,7 +194,7 @@
         }
     ],
     "wof:id":404474683,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878828,
     "wof:name":"Zwartewaterland",
     "wof:parent_id":85687045,
     "wof:placetype":"localadmin",

--- a/data/404/474/685/404474685.geojson
+++ b/data/404/474/685/404474685.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.090328,
     "geom:longitude":4.422307,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.08375,
     "lbl:longitude":4.423592,
     "lbl:max_zoom":14.0,
@@ -157,9 +166,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1916",
         "eg:gisco_id":"NL_GM1916",
         "eurostat:nuts_2021_id":"GM1916"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -175,7 +186,7 @@
         }
     ],
     "wof:id":404474685,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878828,
     "wof:name":"Leidschendam-Voorburg",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/687/404474687.geojson
+++ b/data/404/474/687/404474687.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":52.017538,
     "geom:longitude":4.421955,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":52.018289,
     "lbl:longitude":4.425159,
     "lbl:max_zoom":14.0,
@@ -145,9 +154,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1926",
         "eg:gisco_id":"NL_GM1926",
         "eurostat:nuts_2021_id":"GM1926"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -163,7 +174,7 @@
         }
     ],
     "wof:id":404474687,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878828,
     "wof:name":"Pijnacker-Nootdorp",
     "wof:parent_id":85687041,
     "wof:placetype":"localadmin",

--- a/data/404/474/689/404474689.geojson
+++ b/data/404/474/689/404474689.geojson
@@ -27,6 +27,15 @@
     "geom:latitude":51.916893,
     "geom:longitude":6.213732,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":51.906371,
     "lbl:longitude":6.225671,
     "lbl:max_zoom":14.0,
@@ -142,9 +151,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1955",
         "eg:gisco_id":"NL_GM1955",
         "eurostat:nuts_2021_id":"GM1955"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
@@ -160,7 +171,7 @@
         }
     ],
     "wof:id":404474689,
-    "wof:lastmodified":1684354057,
+    "wof:lastmodified":1695878828,
     "wof:name":"Montferland",
     "wof:parent_id":85687043,
     "wof:placetype":"localadmin",

--- a/data/404/474/691/404474691.geojson
+++ b/data/404/474/691/404474691.geojson
@@ -10,11 +10,20 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010966,
-    "geom:area_square_m":81286070.218559,
+    "geom:area_square_m":81286070.218561,
     "geom:bbox":"6.79403289994,53.1100212973,6.96585535824,53.2273425086",
     "geom:latitude":53.166812,
     "geom:longitude":6.878465,
     "iso:country":"NL",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
+    "label:nld_x_preferred_placetype":[
+        "gemeenten"
+    ],
     "lbl:latitude":53.167524,
     "lbl:longitude":6.862961,
     "lbl:max_zoom":15.0,
@@ -151,13 +160,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "cbsnl:code":"GM1987",
         "hasc:id":"NL.GR.ME"
     },
+    "wof:concordances_official":"cbsnl:code",
     "wof:country":"NL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0702875f3727e8a6bf8c4b1eed8b8b08",
+    "wof:geomhash":"62bfb7280dab403f6b3846eba61de9ab",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -168,7 +179,7 @@
         }
     ],
     "wof:id":404474691,
-    "wof:lastmodified":1582362847,
+    "wof:lastmodified":1695878769,
     "wof:name":"Menterwolde",
     "wof:parent_id":85687059,
     "wof:placetype":"localadmin",

--- a/data/856/333/37/85633337.geojson
+++ b/data/856/333/37/85633337.geojson
@@ -1485,6 +1485,7 @@
         "hasc:id":"NL",
         "icao:code":"PH",
         "ioc:id":"NED",
+        "iso:code":"NL",
         "itu:id":"HOL",
         "m49:code":"528",
         "marc:id":"ne",
@@ -1497,6 +1498,7 @@
         "wd:id":"Q55",
         "wmo:id":"NL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:parent_id",
         "wof:hierarchy"
@@ -1523,7 +1525,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1694492238,
+    "wof:lastmodified":1695881351,
     "wof:name":"Netherlands",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/755/31/85675531.geojson
+++ b/data/856/755/31/85675531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001619,
-    "geom:area_square_m":19098508.794849,
+    "geom:area_square_m":19098444.699635,
     "geom:bbox":"-62.997141,17.464571,-62.945065,17.525621",
     "geom:latitude":17.489196,
     "geom:longitude":-62.974113,
@@ -416,13 +416,15 @@
         "gn:id":7610359,
         "gp:id":24549809,
         "hasc:id":"BQ.SE",
+        "iso:code":"BQ-SE",
         "iso:id":"BQ-SE",
         "qs_pg:id":219954,
         "wd:id":"Q26180",
         "wk:page":"Sint Eustatius"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NL",
-    "wof:geomhash":"aab41cd3e0062b83a21aa8f21fc383d3",
+    "wof:geomhash":"dc3a6506ede3bcbec062004edbd48b9b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -440,7 +442,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848542,
+    "wof:lastmodified":1695884328,
     "wof:name":"St. Eustatius",
     "wof:parent_id":136251281,
     "wof:placetype":"region",

--- a/data/856/755/35/85675535.geojson
+++ b/data/856/755/35/85675535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022355,
-    "geom:area_square_m":270195507.556089,
+    "geom:area_square_m":270195947.364313,
     "geom:bbox":"-68.417388,12.02204,-68.190012,12.310207",
     "geom:latitude":12.18649,
     "geom:longitude":-68.28761,
@@ -538,12 +538,14 @@
         "gn:id":7609816,
         "gp:id":24549811,
         "hasc:id":"BQ.BO",
+        "iso:code":"BQ-BO",
         "iso:id":"BQ-BO",
         "qs_pg:id":1193100,
         "wd:id":"Q27561"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NL",
-    "wof:geomhash":"006026d17b91f76061dea1db03a5c2d7",
+    "wof:geomhash":"0b00611040fb89b0d0c589a159894d9d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -561,7 +563,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848541,
+    "wof:lastmodified":1695884328,
     "wof:name":"Bonaire",
     "wof:parent_id":136251281,
     "wof:placetype":"region",

--- a/data/856/870/33/85687033.geojson
+++ b/data/856/870/33/85687033.geojson
@@ -501,18 +501,24 @@
         101751803
     ],
     "wof:concordances":{
+        "cbsnl:code":"31",
         "digitalenvoy:region_code":10973,
         "eurostat:nuts_2021_id":"NL42",
         "fips:code":"NL05",
         "gn:id":2751596,
         "gp:id":2346377,
         "hasc:id":"NL.LI",
+        "iso:code":"NL-LI",
         "iso:id":"NL-LI",
         "unlc:id":"NL-LI",
         "wd:id":"Q1161"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"74ad312510c5e9ede16c27b54e3c1950",
+    "wof:geomhash":"0100a278ca3e96aa9448b0cea5e439ca",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -529,7 +535,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848544,
+    "wof:lastmodified":1695885171,
     "wof:name":"Limburg",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/35/85687035.geojson
+++ b/data/856/870/35/85687035.geojson
@@ -496,18 +496,24 @@
         101751809
     ],
     "wof:concordances":{
+        "cbsnl:code":"30",
         "digitalenvoy:region_code":10951,
         "eurostat:nuts_2021_id":"NL41",
         "fips:code":"NL06",
         "gn:id":2749990,
         "gp:id":2346378,
         "hasc:id":"NL.NB",
+        "iso:code":"NL-NB",
         "iso:id":"NL-NB",
         "unlc:id":"NL-NB",
         "wd:id":"Q1101"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"919696aaf2958e26e61badb53e7edf6e",
+    "wof:geomhash":"f34f57eb851e066a2a431434d6c49c17",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -524,7 +530,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848543,
+    "wof:lastmodified":1695885171,
     "wof:name":"North Brabant",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/37/85687037.geojson
+++ b/data/856/870/37/85687037.geojson
@@ -471,18 +471,24 @@
         101839435
     ],
     "wof:concordances":{
+        "cbsnl:code":"29",
         "digitalenvoy:region_code":12619,
         "eurostat:nuts_2021_id":"NL34",
         "fips:code":"NL10",
         "gn:id":2744011,
         "gp:id":2346382,
         "hasc:id":"NL.ZE",
+        "iso:code":"NL-ZE",
         "iso:id":"NL-ZE",
         "unlc:id":"NL-ZE",
         "wd:id":"Q705"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"a2432ca3be9c21da7e62d704ac0569a9",
+    "wof:geomhash":"71ab093284d6494de9922e5af98e02c6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -499,7 +505,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848545,
+    "wof:lastmodified":1695885171,
     "wof:name":"Zeeland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/39/85687039.geojson
+++ b/data/856/870/39/85687039.geojson
@@ -522,18 +522,24 @@
         101751827
     ],
     "wof:concordances":{
+        "cbsnl:code":"26",
         "digitalenvoy:region_code":10945,
         "eurostat:nuts_2021_id":"NL31",
         "fips:code":"NL09",
         "gn:id":2745909,
         "gp:id":2346381,
         "hasc:id":"NL.UT",
+        "iso:code":"NL-UT",
         "iso:id":"NL-UT",
         "unlc:id":"NL-UT",
         "wd:id":"Q776"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"57441820528b572eda5e77d262deea38",
+    "wof:geomhash":"7584aa5a209ef5a7332804c1b6181260",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -550,7 +556,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848546,
+    "wof:lastmodified":1695885171,
     "wof:name":"Utrecht",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/41/85687041.geojson
+++ b/data/856/870/41/85687041.geojson
@@ -553,12 +553,14 @@
         101752763
     ],
     "wof:concordances":{
+        "cbsnl:code":"28",
         "digitalenvoy:region_code":3966,
         "eurostat:nuts_2021_id":"NL33",
         "fips:code":"NL11",
         "gn:id":2743698,
         "gp:id":2346383,
         "hasc:id":"NL.ZH",
+        "iso:code":"NL-ZH",
         "iso:id":"NL-ZH",
         "unlc:id":"NL-ZH",
         "wd:id":"Q694"
@@ -568,8 +570,12 @@
             3906
         ]
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"ebe8cf679e37a1015fc724126cf877ef",
+    "wof:geomhash":"2dfabf9be0433846f383169a5d3ae725",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -586,7 +592,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848546,
+    "wof:lastmodified":1695885171,
     "wof:name":"South Holland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/43/85687043.geojson
+++ b/data/856/870/43/85687043.geojson
@@ -510,18 +510,24 @@
         101751857
     ],
     "wof:concordances":{
+        "cbsnl:code":"25",
         "digitalenvoy:region_code":10947,
         "eurostat:nuts_2021_id":"NL22",
         "fips:code":"NL03",
         "gn:id":2755634,
         "gp:id":2346375,
         "hasc:id":"NL.GE",
+        "iso:code":"NL-GE",
         "iso:id":"NL-GE",
         "unlc:id":"NL-GE",
         "wd:id":"Q775"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"08e35dfac829869223ea030d65175452",
+    "wof:geomhash":"d15a107154861bda801d8626b4fc5579",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -538,7 +544,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848544,
+    "wof:lastmodified":1695885171,
     "wof:name":"Gelderland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/45/85687045.geojson
+++ b/data/856/870/45/85687045.geojson
@@ -494,18 +494,24 @@
         101751861
     ],
     "wof:concordances":{
+        "cbsnl:code":"23",
         "digitalenvoy:region_code":10959,
         "eurostat:nuts_2021_id":"NL21",
         "fips:code":"NL15",
         "gn:id":2748838,
         "gp:id":2346380,
         "hasc:id":"NL.OV",
+        "iso:code":"NL-OV",
         "iso:id":"NL-OV",
         "unlc:id":"NL-OV",
         "wd:id":"Q773"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"79e512453ca97e6252eb051cc37fd35b",
+    "wof:geomhash":"4ed460ae41fa5b03bf6ea66444b73377",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -522,7 +528,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848544,
+    "wof:lastmodified":1695885171,
     "wof:name":"Overijssel",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/49/85687049.geojson
+++ b/data/856/870/49/85687049.geojson
@@ -495,18 +495,24 @@
         101751873
     ],
     "wof:concordances":{
+        "cbsnl:code":"24",
         "digitalenvoy:region_code":10944,
         "eurostat:nuts_2021_id":"NL23",
         "fips:code":"NL16",
         "gn:id":3319179,
         "gp:id":2346384,
         "hasc:id":"NL.FL",
+        "iso:code":"NL-FL",
         "iso:id":"NL-FL",
         "unlc:id":"NL-FL",
         "wd:id":"Q707"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"c228121ed77bf625b4f2db9c3f68beb7",
+    "wof:geomhash":"a6b322e8b1dfc78545db4fd27e6ad317",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -523,7 +529,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848547,
+    "wof:lastmodified":1695885171,
     "wof:name":"Flevoland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/51/85687051.geojson
+++ b/data/856/870/51/85687051.geojson
@@ -476,18 +476,24 @@
         101751879
     ],
     "wof:concordances":{
+        "cbsnl:code":"22",
         "digitalenvoy:region_code":10949,
         "eurostat:nuts_2021_id":"NL13",
         "fips:code":"NL01",
         "gn:id":2756631,
         "gp:id":2346373,
         "hasc:id":"NL.DR",
+        "iso:code":"NL-DR",
         "iso:id":"NL-DR",
         "unlc:id":"NL-DR",
         "wd:id":"Q772"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"aa665006eb0187b3a94d3cbd4c5557f1",
+    "wof:geomhash":"694c31ea6307bad0103d7269e4c4daae",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -504,7 +510,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848543,
+    "wof:lastmodified":1695885171,
     "wof:name":"Drenthe",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/53/85687053.geojson
+++ b/data/856/870/53/85687053.geojson
@@ -505,17 +505,23 @@
         101751897
     ],
     "wof:concordances":{
+        "cbsnl:code":"27",
         "eurostat:nuts_2021_id":"NL32",
         "fips:code":"NL07",
         "gn:id":2749879,
         "gp:id":2346379,
         "hasc:id":"NL.NH",
+        "iso:code":"NL-NH",
         "iso:id":"NL-NH",
         "unlc:id":"NL-NH",
         "wd:id":"Q701"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"febd2bc5cd9b6edda13f56482b0d9407",
+    "wof:geomhash":"2043236a72a9ef3c5f23d5c6f55c9781",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -532,7 +538,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848545,
+    "wof:lastmodified":1695885171,
     "wof:name":"North Holland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/55/85687055.geojson
+++ b/data/856/870/55/85687055.geojson
@@ -541,17 +541,23 @@
         101751907
     ],
     "wof:concordances":{
+        "cbsnl:code":"21",
         "digitalenvoy:region_code":10981,
         "eurostat:nuts_2021_id":"NL12",
         "fips:code":"NL02",
         "gn:id":2755812,
         "gp:id":2346374,
         "hasc:id":"NL.FR",
+        "iso:code":"NL-FR",
         "iso:id":"NL-FR",
         "wd:id":"Q770"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"cb3493e137d1cd25b7d8ab6408b8a633",
+    "wof:geomhash":"2257b48de4f0435eb25a9f2ed4d308a2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -568,7 +574,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848546,
+    "wof:lastmodified":1695885171,
     "wof:name":"Friesland",
     "wof:parent_id":85633337,
     "wof:placetype":"region",

--- a/data/856/870/59/85687059.geojson
+++ b/data/856/870/59/85687059.geojson
@@ -459,18 +459,24 @@
         101751909
     ],
     "wof:concordances":{
+        "cbsnl:code":"20",
         "digitalenvoy:region_code":10950,
         "eurostat:nuts_2021_id":"NL11",
         "fips:code":"NL04",
         "gn:id":2755249,
         "gp:id":2346376,
         "hasc:id":"NL.GR",
+        "iso:code":"NL-GR",
         "iso:id":"NL-GR",
         "unlc:id":"NL-GR",
         "wd:id":"Q752"
     },
+    "wof:concordances_official":"cbsnl:code",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"NL",
-    "wof:geomhash":"a8926e8e0bda2f65584f2c35a4ff6832",
+    "wof:geomhash":"4649f4404455cbd47fa30f0ef3d6b7ae",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -487,7 +493,7 @@
         "nld",
         "fry"
     ],
-    "wof:lastmodified":1690848542,
+    "wof:lastmodified":1695885171,
     "wof:name":"Groningen",
     "wof:parent_id":85633337,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.